### PR TITLE
Added down command window to avoid falling too fast

### DIFF
--- a/roscopter/params/multirotor.yaml
+++ b/roscopter/params/multirotor.yaml
@@ -1,13 +1,13 @@
 /**:    # autopilot and trajectory controller share some of the same parameters
     ros__parameters:
         # Autopilot gains
-        roll_kp: 0.4
+        roll_kp: 6.0
         roll_ki: 0.0
-        roll_kd: 0.2
-        pitch_kp: 0.4
+        roll_kd: 1.0
+        pitch_kp: 6.0
         pitch_ki: 0.0
-        pitch_kd: 0.2
-        yaw_kp: 0.2
+        pitch_kd: 1.0
+        yaw_kp: 0.8
         yaw_ki: 0.002
         yaw_kd: 0.2
 
@@ -61,22 +61,24 @@
         max_throttle: 0.85
         min_throttle: 0.05
 
-        max_roll: 15.0      # degrees
-        max_pitch: 15.0     # degrees
+        max_roll: 30.0      # degrees
+        max_pitch: 30.0     # degrees
 
         max_descend_accel: 1.0  # in g's
         max_descend_rate: 3.0
 
+        down_command_window: 3.0
+
         # Trajectory controller gains
         u_n_kp: 0.5
-        u_n_ki: 0.1
+        u_n_ki: 0.001
         u_n_kd: 0.5
         u_e_kp: 0.5
-        u_e_ki: 0.1
+        u_e_ki: 0.001
         u_e_kd: 0.5
         u_d_kp: 4.0
-        u_d_ki: 0.1
-        u_d_kd: 15.0
+        u_d_ki: 0.4
+        u_d_kd: 4.0
 
         # Miscellanous
         tau: 0.05

--- a/roscopter/src/controller/simple_pid.cpp
+++ b/roscopter/src/controller/simple_pid.cpp
@@ -120,7 +120,6 @@ double SimplePID::compute_pid(double desired, double current, double dt, double 
 
   // Integrator anti-windup
   double u_sat = saturate(u, min_, max_);
-  // TODO: Do we need the second check here?
   if (u != u_sat && std::fabs(i_term) > fabs(u_sat - p_term + d_term)) {
     // If we are at the saturation limits, then make sure the integrator doesn't get
     // bigger if it won't do anything (except take longer to unwind).  Just set it to the

--- a/roscopter/src/navigation/trajectory_follower.cpp
+++ b/roscopter/src/navigation/trajectory_follower.cpp
@@ -38,6 +38,7 @@ void TrajectoryFollower::declare_params()
   params.declare_double("max_roll", 30.0);
   params.declare_double("max_pitch", 30.0);
   params.declare_double("max_descend_accel", 1.0);
+  params.declare_double("down_command_window", 3.0);
 }
 
 void TrajectoryFollower::update_gains()
@@ -159,6 +160,13 @@ double TrajectoryFollower::down_control(double pd_cmd, double pd_dot_cmd, double
   double C_d = params.get_double("C_d");
   double g = params.get_double("gravity");
   double min_accel_z = params.get_double("max_descend_accel") * g;
+  double max_d_cmd = params.get_double("down_command_window");
+
+  // Saturate the down command (only when positive) to the maximum down command window.
+  // This helps to ensure that the copter maintains a controllable down velocity when descending
+  if ((pd_cmd - xhat_.position[2]) > max_d_cmd) {
+    pd_cmd = max_d_cmd + xhat_.position[2];
+  }
 
   // Down control effort - Eq. 14.34. Note the negative velocity passed to the PID object
   double pd_dot_tilde = pd_dot_cmd - xhat_.v_d;


### PR DESCRIPTION
This pull request implements a sliding window for the down command. If the down command is too large, then the quad descends too quickly, resulting in an uncontrollable maneuver. The sliding window alleviates this by saturating the maximum down command. This also allows the controller to have gains high enough to have good performance when ascending, while also staying safe when descending.