### PR TITLE
Fix path manager previous waypoint

### DIFF
--- a/roscopter/include/navigation/path_manager.hpp
+++ b/roscopter/include/navigation/path_manager.hpp
@@ -30,6 +30,7 @@ private:
   roscopter_msgs::msg::TrajectoryCommand linear_interpolation();
   void hold_timer_callback();
   void increment_wp_index();
+  roscopter_msgs::msg::Waypoint compute_previous_waypoint();
   void clear_waypoints_internally() override;
   void rk4_step();
   Eigen::Vector2f F(Eigen::Vector2f sig);


### PR DESCRIPTION
This PR fixes an issue in ROScopter's path manager that was incorrectly setting the previous waypoint to the incorrect location when creating a trajectory.

There were two symptoms I found that this fixes:
- Adding waypoints sequentially using the `add_waypoint` service call now results in expected behavior
- If the `path_manager`'s `hold_last` param is set to false, it will now cycle between waypoints in the waypoint list, even if there are only 2 waypoints.

Closes #30 