### PR TITLE
fix: trajectory follower saturate down commanded accel

### DIFF
--- a/roscopter/include/navigation/trajectory_follower.hpp
+++ b/roscopter/include/navigation/trajectory_follower.hpp
@@ -32,6 +32,7 @@ private:
   double compute_theta_dot(const Eigen::Vector3d z, double thrust, const Eigen::Vector4d u);
   Eigen::Matrix3d R_psi(double psi);
   double wrap_within_180(double datum, double angle_to_wrap);
+  void saturate_commmand_vector(Eigen::Vector4d& u);
   Eigen::Vector4d compute_control_input(const double pn_cmd, const double pe_cmd, const double pd_cmd, const double psi_cmd,
                                         const double vn, const double ve, const double vd);
   double north_control(const double pn_cmd, const double vn);


### PR DESCRIPTION
This PR fixes #38 by saturating the maximum down acceleration to a user-defined value.

Specifically, I
1. Changed the `atan2` function call to `atan`, since we never want to return values in quadrants 2 and 3 ($pi/2$ to $pi$) anyway.
2. Added the `max_commanded_down_accel_in_gs` param to the trajectory follower.

Number 1 fixes most of the problem. However, when the z component of acceleration passes through 0, we still get spikes and jumps (since $\theta=\text{atan}(u_x / u_z)$ and $u_z$=0 is bad). This means we still need number 2 to keep the total commanded down acceleration in the inertial frame) away from zero.

Note that I am saturating the commanded down acceleration **after** gravity has been subtracted from the input command. This means that if $u_z$ saturates to 0, then the throttle command will be zero (assuming $u_x$ and $u_y$ are also zero). If, however, $u_z$ saturates to 1g = 9.81 m/s, then this means that the throttle setting will be enough to generate 1g force (keeping the copter in hover).

Since we use the NED frame, the `max_commanded_down_accel_in_gs` parameter should always be negative (i.e. the max down acceleration is still pointing up a little). This means that we will never turn off the motors and operate in free fall, but instead will have some minimum applied force in the up direction. This helps maintain stability. Furthermore, the max down acceleration should not be greater than -1. If greater than -1, then the copter will continuously accelerate up.