### PR TITLE
fix: add roscopter_gcs to roscopter_sim launch file

### DIFF
--- a/roscopter_sim/launch/sim.launch.py
+++ b/roscopter_sim/launch/sim.launch.py
@@ -22,9 +22,14 @@ def generate_launch_description():
     return LaunchDescription([
         base_launch_include,
         Node(
+            package='roscopter_gcs',
+            executable='rviz_waypoint_publisher',
+            output='screen',
+        ),
+        Node(
             package='roscopter_sim',
             executable='sim_state_transcriber',
             output='screen',
             name='roscopter_truth'
-        )
+        ),
     ])


### PR DESCRIPTION
I forgot to add this functionality to #44 . This enables the default standalone sim to publish waypoints out of the box.

Note that the `roscopter_gcs` launch file still publishes waypoints for in-field testing.