### PR TITLE
Modernize ROS 2 package builds for Ubuntu 26

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -26,6 +26,9 @@ jobs:
           - ros_distro: 'jazzy'
             os: ubuntu-24.04
             container: osrf/ros:jazzy-desktop
+          - ros_distro: 'lyrical'
+            os: ubuntu-26.04
+            container: osrf/ros:lyrical-desktop
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -2,9 +2,9 @@ name: ROS2 CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   BUILD_TYPE: Release
@@ -18,15 +18,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro: [ humble, jazzy ]
+        ros_distro: [humble, jazzy]
         include:
-          - ros_distro: 'humble'
+          - ros_distro: "humble"
             os: ubuntu-22.04
             container: osrf/ros:humble-desktop
-          - ros_distro: 'jazzy'
+          - ros_distro: "jazzy"
             os: ubuntu-24.04
             container: osrf/ros:jazzy-desktop
-          - ros_distro: 'lyrical'
+          - ros_distro: "lyrical"
             os: ubuntu-26.04
             container: osrf/ros:lyrical-desktop
     defaults:
@@ -37,15 +37,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-          path: 'ros2_ws/src/roscopter'
+          path: "ros2_ws/src/roscopter"
 
       - name: Checkout rosflight_msgs
         uses: actions/checkout@v6
         with:
           repository: rosflight/rosflight
-          path: 'ros2_ws/src/rosflight'
+          path: "ros2_ws/src/rosflight"
           sparse-checkout: |
             rosflight_msgs
+            rosflight_compat
           sparse-checkout-cone-mode: false
 
       - name: Update system
@@ -64,4 +65,3 @@ jobs:
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           cd ros2_ws
           colcon build --event-handlers console_direct+
-

--- a/roscopter/CMakeLists.txt
+++ b/roscopter/CMakeLists.txt
@@ -1,167 +1,180 @@
-set(CMAKE_CXX_STANDARD 14)
-cmake_minimum_required(VERSION 3.8)
-project(roscopter)
-
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+cmake_minimum_required(VERSION 3.20...3.28)
+project(roscopter LANGUAGES C CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclpy REQUIRED)
-find_package(roscopter_msgs REQUIRED)
-find_package(rosflight_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
-pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+find_package(sensor_msgs REQUIRED)
+find_package(rosflight_compat REQUIRED)
+find_package(rosflight_msgs REQUIRED)
+find_package(roscopter_msgs REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
-ament_export_include_directories(include ${EIGEN3_INCLUDE_DIRS})
-ament_export_dependencies(rclcpp rclpy roscopter_msgs rosflight_msgs std_msgs sensor_msgs Eigen3 geometry_msgs)
-
-add_definitions(-DROSCOPTER_DIR="${CMAKE_CURRENT_LIST_DIR}")
-
-install(
-  DIRECTORY launch params 
-  DESTINATION share/${PROJECT_NAME})
-
-###########
-## Build ##
-###########
-
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS} 
-  ${ament_INCLUDE_DIRS}
-  ${YAML_CPP_INCLUDEDIR}
+# Legacy yaml-cpp support for Ubuntu 22.04
+if(NOT TARGET yaml-cpp::yaml-cpp)
+  add_library(yaml-cpp::yaml-cpp INTERFACE IMPORTED)
+  set_target_properties(yaml-cpp::yaml-cpp PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${YAML_CPP_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${YAML_CPP_LIBRARIES}"
   )
+endif()
 
-
+#################
 ### LIBRARIES ###
+#################
 
-# Param Manager
-add_library(param_manager
-  include/param_manager/param_manager.hpp
-  src/param_manager/param_manager.cpp
+# Param Manager (exported)
+add_library(roscopter_param_manager src/param_manager/param_manager.cpp)
+add_library(roscopter::param_manager ALIAS roscopter_param_manager)
+set_target_properties(roscopter_param_manager PROPERTIES
+  EXPORT_NAME param_manager
 )
-ament_target_dependencies(param_manager rclcpp)
-ament_export_targets(param_manager HAS_LIBRARY_TARGET)
-install(DIRECTORY include/param_manager DESTINATION include)
-install(TARGETS param_manager
-  EXPORT param_manager
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+target_compile_features(roscopter_param_manager PUBLIC cxx_std_17)
+target_compile_options(roscopter_param_manager PRIVATE -Wall -Wextra -Wpedantic)
+target_include_directories(roscopter_param_manager PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
+target_link_libraries(roscopter_param_manager PUBLIC rclcpp::rclcpp)
 
-# ESTIMATOR LIB
-set_source_files_properties(geomag.c PROPERTIES LANGUAGE C)
-add_library(estimation_lib SHARED
+# Estimation (exported)
+set_source_files_properties(src/utils/geomag.c PROPERTIES
+  LANGUAGE C
+  COMPILE_OPTIONS "-Wno-overlength-strings"
+)
+add_library(roscopter_estimation
   src/ekf/estimator_ros.cpp
   src/ekf/estimator_ekf.cpp
   src/ekf/estimator_continuous_discrete.cpp
-  src/utils/geomag.c)
-target_include_directories(estimation_lib
-  PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/ekf>"
-    "$<INSTALL_INTERFACE:include/ekf>")
-ament_target_dependencies(estimation_lib rclcpp geometry_msgs rosflight_msgs sensor_msgs Eigen3 roscopter_msgs ament_index_cpp)
-install(DIRECTORY include/ekf DESTINATION include)
-install(TARGETS estimation_lib
-  EXPORT export_estimation_lib
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
+  src/utils/geomag.c
 )
-ament_export_targets(export_estimation_lib HAS_LIBRARY_TARGET)
+add_library(roscopter::estimation ALIAS roscopter_estimation)
+target_compile_features(roscopter_estimation PUBLIC c_std_99 cxx_std_17)
+target_compile_options(roscopter_estimation PRIVATE -Wall -Wextra -Wpedantic)
+target_include_directories(roscopter_estimation PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+target_link_libraries(roscopter_estimation
+  PUBLIC
+    roscopter::param_manager
+    rclcpp::rclcpp
+    sensor_msgs::sensor_msgs
+    rosflight_msgs::rosflight_msgs
+    roscopter_msgs::roscopter_msgs
+    Eigen3::Eigen
+  PRIVATE
+    rosflight_compat::compat_headers # FIXME: legacy support for Humble
+    # ament_index_cpp::ament_index_cpp # FIXME: use when Humble is dropped
+)
 
+###################
 ### EXECUTABLES ###
+###################
 
 # Estimator
-add_executable(estimator
-              src/ekf/estimator_node.cpp)
-ament_target_dependencies(estimator PUBLIC roscopter_msgs rosflight_msgs sensor_msgs rclcpp Eigen3 ament_index_cpp)
-target_link_libraries(estimator PUBLIC estimation_lib ${ament_LIBRARIES} param_manager ${YAML_CPP_LIBRARIES})
-target_include_directories(estimator PUBLIC include)
-install(TARGETS
-  estimator
-  DESTINATION lib/${PROJECT_NAME})
+add_executable(estimator src/ekf/estimator_node.cpp)
+target_compile_features(estimator PRIVATE cxx_std_17)
+target_compile_options(estimator PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(estimator PRIVATE roscopter::estimation)
 
 # External attitude transcriber
-add_executable(ext_att_transcriber
-  src/ekf/external_attitude_transcriber.cpp)
-ament_target_dependencies(ext_att_transcriber rclcpp roscopter_msgs rosflight_msgs)
-target_link_libraries(ext_att_transcriber ${ament_LIBRARIES})
-install(TARGETS ext_att_transcriber
-  DESTINATION lib/${PROJECT_NAME})
+add_executable(ext_att_transcriber src/ekf/external_attitude_transcriber.cpp)
+target_compile_features(ext_att_transcriber PRIVATE cxx_std_17)
+target_compile_options(ext_att_transcriber PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(ext_att_transcriber PRIVATE
+  rclcpp::rclcpp
+  rosflight_msgs::rosflight_msgs
+  roscopter_msgs::roscopter_msgs
+)
 
 # Controller
 add_executable(controller
   src/controller/controller_ros.cpp
   src/controller/controller_state_machine.cpp
   src/controller/controller_cascading_pid.cpp
-  src/controller/simple_pid.cpp)
-ament_target_dependencies(controller rclcpp rclpy roscopter_msgs rosflight_msgs Eigen3)
-target_link_libraries(controller ${ament_LIBRARIES} param_manager)
-install(
-  TARGETS controller
-  DESTINATION lib/${PROJECT_NAME})
+  src/controller/simple_pid.cpp
+)
+target_compile_features(controller PRIVATE cxx_std_17)
+target_compile_options(controller PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(controller PRIVATE
+  roscopter::param_manager
+  rclcpp::rclcpp
+  rosflight_msgs::rosflight_msgs
+  roscopter_msgs::roscopter_msgs
+  Eigen3::Eigen
+)
 
 # Trajectory Follower
 add_executable(trajectory_follower
   src/navigation/trajectory_follower_ros.cpp
   src/navigation/trajectory_follower.cpp
-  src/controller/simple_pid.cpp)
-ament_target_dependencies(trajectory_follower rclcpp rclpy roscopter_msgs std_srvs rosflight_msgs Eigen3)
-target_link_libraries(trajectory_follower ${ament_LIBRARIES} param_manager)
-install(
-  TARGETS trajectory_follower
-  DESTINATION lib/${PROJECT_NAME})
+  src/controller/simple_pid.cpp
+)
+target_compile_features(trajectory_follower PRIVATE cxx_std_17)
+target_compile_options(trajectory_follower PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(trajectory_follower PRIVATE
+  roscopter::param_manager
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  rosflight_msgs::rosflight_msgs
+  roscopter_msgs::roscopter_msgs
+  Eigen3::Eigen
+)
 
 # Path Manager
 add_executable(path_manager
   src/navigation/path_manager_ros.cpp
-  src/navigation/path_manager.cpp)
-ament_target_dependencies(path_manager rclcpp rclpy roscopter_msgs std_srvs)
-target_link_libraries(path_manager ${ament_LIBRARIES} param_manager)
-install(
-  TARGETS path_manager
-  DESTINATION lib/${PROJECT_NAME})
+  src/navigation/path_manager.cpp
+)
+target_compile_features(path_manager PRIVATE cxx_std_17)
+target_compile_options(path_manager PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(path_manager PRIVATE
+  roscopter::param_manager
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  roscopter_msgs::roscopter_msgs
+  Eigen3::Eigen
+)
 
 # Path Planner
-add_executable(path_planner
-  src/navigation/path_planner.cpp)
-ament_target_dependencies(path_planner rclcpp roscopter_msgs std_srvs rosflight_msgs)
-target_link_libraries(path_planner ${ament_LIBRARIES} param_manager ${YAML_CPP_LIBRARIES})
-install(
-  TARGETS path_planner
-  DESTINATION lib/${PROJECT_NAME})
+add_executable(path_planner src/navigation/path_planner.cpp)
+target_compile_features(path_planner PRIVATE cxx_std_17)
+target_compile_options(path_planner PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(path_planner PRIVATE
+  roscopter::param_manager
+  rosflight_compat::compat_headers
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  rosflight_msgs::rosflight_msgs
+  roscopter_msgs::roscopter_msgs
+  yaml-cpp::yaml-cpp
+)
 
+###############
+### Testing ###
+###############
 
 if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(estimator_test test/estimator_test.cpp)
-  ament_target_dependencies(estimator_test rclcpp geometry_msgs rosflight_msgs sensor_msgs Eigen3 roscopter_msgs)
-  target_include_directories(estimator_test PUBLIC
-    include
+  target_link_libraries(estimator_test
+    roscopter::estimation
+    rclcpp::rclcpp
+    geometry_msgs::geometry_msgs
+    sensor_msgs::sensor_msgs
+    rosflight_msgs::rosflight_msgs
+    roscopter_msgs::roscopter_msgs
+    Eigen3::Eigen
   )
-  target_link_libraries(estimator_test estimation_lib param_manager) 
 
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
@@ -173,5 +186,64 @@ if(BUILD_TESTING)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+###############
+### Install ###
+###############
+
+# Headers for exported/public libraries
+install(
+  DIRECTORY
+    include/param_manager
+    include/ekf
+  DESTINATION include/${PROJECT_NAME}
+)
+
+# Exported/public libraries
+install(
+  TARGETS
+    roscopter_param_manager
+    roscopter_estimation
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# C++ nodes/executables
+install(
+  TARGETS
+    estimator
+    ext_att_transcriber
+    controller
+    trajectory_follower
+    path_manager
+    path_planner
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Resources
+install(
+  DIRECTORY
+    launch
+    params
+  DESTINATION share/${PROJECT_NAME}
+)
+
+########################
+### ROS Finalization ###
+########################
+
+# export custom libraries
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+# export public cmake package dependencies (not targets)
+ament_export_dependencies(
+  rclcpp
+  rosflight_msgs
+  roscopter_msgs
+  sensor_msgs
+  Eigen3
+)
 
 ament_package()

--- a/roscopter/include/controller/controller_cascading_pid.hpp
+++ b/roscopter/include/controller/controller_cascading_pid.hpp
@@ -1,7 +1,6 @@
 #ifndef CONTROLLER_CASCADING_PID_HPP
 #define CONTROLLER_CASCADING_PID_HPP
 
-#include <cfloat>
 #include <Eigen/Geometry>
 
 #include <controller/controller_state_machine.hpp>

--- a/roscopter/include/ekf/estimator_continuous_discrete.hpp
+++ b/roscopter/include/ekf/estimator_continuous_discrete.hpp
@@ -1,15 +1,12 @@
 #ifndef ESTIMATOR_CONTINUOUS_DISCRETE_H // FIXME: redefine the header guards when you rename the ekf.
 #define ESTIMATOR_CONTINUOUS_DISCRETE_H
 
+#include <Eigen/Geometry>
 #include <math.h>
 
-#include <Eigen/Geometry>
-#include "geomag.h"
-
-#include <cmath>
-
-#include "estimator_ekf.hpp"
-#include "estimator_ros.hpp"
+#include "ekf/estimator_ekf.hpp"
+#include "ekf/estimator_ros.hpp"
+#include "ekf/geomag.h"
 
 namespace roscopter
 {

--- a/roscopter/include/ekf/estimator_continuous_discrete.hpp
+++ b/roscopter/include/ekf/estimator_continuous_discrete.hpp
@@ -27,27 +27,27 @@ private:
   /**
    * @brief The low pass filter alpha value used on the gyro.
    */
-  float alpha_gyro_;
+  double alpha_gyro_;
   
   /**
    * @brief The low pass filter alpha value used on the barometer.
    */
-  float alpha_baro_;
+  double alpha_baro_;
 
   /**
    * @brief The value of the low pass filtered gyroscope measurement.
    */
-  float lpf_gyro_x_;
+  double lpf_gyro_x_;
 
   /**
    * @brief The value of the low pass filtered gyroscope measurement.
    */
-  float lpf_gyro_y_;
+  double lpf_gyro_y_;
 
   /**
    * @brief The value of the low pass filtered gyroscope measurement.
    */
-  float lpf_gyro_z_;
+  double lpf_gyro_z_;
 
   /**
    * @brief This function calculates the derivatives of the state. This is dictated by the dynamics of
@@ -56,7 +56,7 @@ private:
    * @param state The state of the system. 
    * @param inputs The inputs to the estimator. Can be something like IMU measurements.
    */
-  Eigen::VectorXf dynamics(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs);
+  Eigen::VectorXd dynamics(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs);
 
   /**
    * @brief This is a reference to the dynamics function, this is created by the std::bind.
@@ -70,7 +70,7 @@ private:
    * @param state The state of the system.
    * @param inputs The inputs to the estimator, something like IMU measurements.
    */
-  Eigen::MatrixXf jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs);
+  Eigen::MatrixXd jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs);
 
   /**
    * @brief This is a reference to the jacobian function, this is created by the std::bind.
@@ -84,7 +84,7 @@ private:
    * @param state The state of the dynamic system.
    * @param inputs Inputs to the estimator.
    */
-  Eigen::MatrixXf input_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs);
+  Eigen::MatrixXd input_jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs);
 
   /**
    * @brief This is a reference to the input_jacobian function. This incurs minimum time cost
@@ -99,7 +99,7 @@ private:
    * @param input Inputs to the measurement prediction. Essentially information necessary to the prediction,
    * but is not contained in the state.
    */
-  Eigen::VectorXf gnss_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::VectorXd gnss_measurement_prediction(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   /**
    * @brief This is a reference to the measurement_prediction function. This incurs minimum time cost
    * when passing into a function.
@@ -112,7 +112,7 @@ private:
    * @param state State of the system.
    * @param input Any necessary inputs not included in the state.
    */
-  Eigen::MatrixXf gnss_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd gnss_measurement_jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
 
   /**
    * @brief This is a reference to the measurement_jacobian function. This incurs minimum time cost
@@ -123,17 +123,17 @@ private:
   /**
    * @brief This function returns the GNSS measurement noise.
    */
-  Eigen::MatrixXf gnss_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd gnss_measurement_sensor_noise(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
 
   /**
    * @brief Calculates the partial of gravity in the body frame with respect to the Euler angles.
    */
-  Eigen::Matrix<float, 3,3> del_R_Theta_T_g_del_Theta(const Eigen::Vector3f& Theta, const double& gravity);
+  Eigen::Matrix3d del_R_Theta_T_g_del_Theta(const Eigen::Vector3d& Theta, const double& gravity);
 
   /**
    * @brief Calculates the partial the inertial velocities with respect to the Euler angles.
    */
-  Eigen::Matrix<float, 3,3> del_R_Theta_v_del_Theta(const Eigen::Vector3f& Theta, const Eigen::Vector3f& vels);
+  Eigen::Matrix3d del_R_Theta_v_del_Theta(const Eigen::Vector3d& Theta, const Eigen::Vector3d& vels);
 
   /**
    * @brief Acceleration due to gravity in m/s^2.
@@ -152,7 +152,7 @@ private:
    * @param input Inputs to the measurement prediction. Essentially information necessary to the prediction,
    * but is not contained in the state.
    */
-  Eigen::VectorXf tilt_mag_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::VectorXd tilt_mag_measurement_prediction(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
 
   /**
    * @brief This is a reference to the mag_measurement_prediction function. This incurs minimum time cost
@@ -166,7 +166,7 @@ private:
    * @param state State of the system.
    * @param input Any inputs not in the state needed for the system.
    */
-  Eigen::MatrixXf tilt_mag_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd tilt_mag_measurement_jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   
   /**
    * @brief This is a reference to the mag_measurement_jacobian function. This incurs minimum time cost
@@ -177,7 +177,7 @@ private:
   /**
    * @brief Calculates the sensor noise of the magnetometer.
    */
-  Eigen::MatrixXf tilt_mag_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd tilt_mag_measurement_sensor_noise(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   
   /**
    * @brief Reference to the magnetometer sensor noise calculation.
@@ -191,7 +191,7 @@ private:
    * @param input Inputs to the measurement prediction. Essentially information necessary to the prediction,
    * but is not contained in the state.
    */
-  Eigen::VectorXf baro_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::VectorXd baro_measurement_prediction(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   /**
    * @brief This is a reference to the baro_measurement_prediction function. This incurs minimum time cost
    * when passing into a function.
@@ -204,7 +204,7 @@ private:
    * @param state State of the system.
    * @param input Any inputs not in the state needed for the system.
    */
-  Eigen::MatrixXf baro_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd baro_measurement_jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   /**
    * @brief This is a reference to the baro_measurement_jacobian function. This incurs minimum time cost
    * when passing into a function.
@@ -214,7 +214,7 @@ private:
   /**
    * @brief Calculates the barometer sensor noise.
    */
-  Eigen::MatrixXf baro_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input);
+  Eigen::MatrixXd baro_measurement_sensor_noise(const Eigen::VectorXd& state, const Eigen::VectorXd& input);
   
   /**
    * @brief Reference to the calculation of the barometer sensor noise.
@@ -229,16 +229,16 @@ private:
   /**
    * @brief The state of the system.
    */
-  Eigen::Vector<float, num_states> xhat_;
+  Eigen::Vector<double, num_states> xhat_;
   /**
    * @brief The covariance of the estimate.
    */
-  Eigen::Matrix<float, num_states, num_states> P_;
+  Eigen::Matrix<double, num_states, num_states> P_;
 
   /**
    * @brief The process noise for state propagation.
    */
-  Eigen::Matrix<float, num_states, num_states> Q_;
+  Eigen::Matrix<double, num_states, num_states> Q_;
   
   /**
    * @brief There are 6 estimator inputs by default. accel_x, accel_y, accel_z, omega_x, omega_y and omega_z.
@@ -249,7 +249,7 @@ private:
    * @brief The process noise from the inputs to the estimator, accelerations (3) and angular velocities (3).
    * The first 3 rows are for the accels, and the second 3 for the angular velocities.
    */
-  Eigen::Matrix<float, num_estimator_inputs, num_estimator_inputs> Q_inputs_;
+  Eigen::Matrix<double, num_estimator_inputs, num_estimator_inputs> Q_inputs_;
 
   /**
    * @brief There are 6 gnss measurements by default. Lat, lon, alt, v_n, v_e and v_d.
@@ -260,7 +260,7 @@ private:
    * @brief The sensor noises for the GNSS measurements. The first three rows are for the positional measurements.
    * The last three rows are for the velocity measurements.
    */
-  Eigen::Matrix<float, num_gnss_measurements, num_gnss_measurements> R_gnss_;
+  Eigen::Matrix<double, num_gnss_measurements, num_gnss_measurements> R_gnss_;
 
   /**
    * @brief There is just one value that calculates to tilt mag heading.
@@ -270,7 +270,7 @@ private:
   /**
    * @brief The sensor noise not due to the mag or state in the tilt mag measurement.
    */
-  Eigen::Matrix<float, num_tilt_mag_measurements,num_tilt_mag_measurements> R_tilt_;
+  Eigen::Matrix<double, num_tilt_mag_measurements,num_tilt_mag_measurements> R_tilt_;
   
   /**
    * @brief There are 3 mag measurements by default. m_x, m_y and m_z.
@@ -280,7 +280,7 @@ private:
   /**
    * @brief The sensor noises for the magnetometer.
    */
-  Eigen::Matrix<float, num_mag_measurements, num_mag_measurements> R_mag_;
+  Eigen::Matrix<double, num_mag_measurements, num_mag_measurements> R_mag_;
   
   /**
    * @brief There is one barometer measurement by default. P (pressure).
@@ -290,7 +290,7 @@ private:
   /**
    * @brief The sensor noises for the barometer.
    */
-  Eigen::Matrix<float, num_baro_measurements, num_baro_measurements> R_baro_;
+  Eigen::Matrix<double, num_baro_measurements, num_baro_measurements> R_baro_;
   
   /**
    * @brief The calculated inclination of the magnetic field at the current location.
@@ -340,32 +340,32 @@ private:
   /**
    * @brief Calculates the inertial magnetic field.
    */
-  Eigen::Vector3f calculate_inertial_magnetic_field(const float& declination, const float& inclination);
+  Eigen::Vector3d calculate_inertial_magnetic_field(const double& declination, const double& inclination);
   
   /**
    * @brief Calculates the body to inertial rotation matrix.
    */
-  Eigen::Matrix3f R(const Eigen::Vector3f& Theta);
+  Eigen::Matrix3d R(const Eigen::Vector3d& Theta);
   
   /**
    * @brief Calculates the matrix that integrates gyro measurements into Euler angles.
    */
-  Eigen::Matrix3f S(const Eigen::Vector3f& Theta);
+  Eigen::Matrix3d S(const Eigen::Vector3d& Theta);
   
   /**
    * @brief Calculates the partial of the gyro integration matrix with respect to the Euler angles.
    */
-  Eigen::Matrix3f del_S_Theta_del_Theta(const Eigen::Vector3f& Theta, const Eigen::Vector3f& biases, const Eigen::Vector3f& gyro);
+  Eigen::Matrix3d del_S_Theta_del_Theta(const Eigen::Vector3d& Theta, const Eigen::Vector3d& biases, const Eigen::Vector3d& gyro);
 
   /**
    * @brief Calculates the partial of tilt compensated mag measurement with respect to the states.
    */
-  Eigen::MatrixXf del_tilt_mag_del_states(const Eigen::VectorXf& state, const Eigen::VectorXf& info);
+  Eigen::MatrixXd del_tilt_mag_del_states(const Eigen::VectorXd& state, const Eigen::VectorXd& info);
 
   /**
    * @brief Calculates the partial of tilt compensated mag measurement with respect to the magnetometer measurements.
    */
-  Eigen::MatrixXf del_tilt_mag_del_mag(const Eigen::VectorXf& state, const Eigen::VectorXf& info);
+  Eigen::MatrixXd del_tilt_mag_del_mag(const Eigen::VectorXd& state, const Eigen::VectorXd& info);
 
   /**
    * @brief This function binds references to the functions used in the ekf.

--- a/roscopter/include/ekf/estimator_ekf.hpp
+++ b/roscopter/include/ekf/estimator_ekf.hpp
@@ -11,10 +11,10 @@
 #include "estimator_ros.hpp"
 
 // These declutter code, and incur a minimum time cost when passing these types to functions.
-using DynamicModelFuncRef = std::function<Eigen::VectorXf(const Eigen::VectorXf, const Eigen::VectorXf)>;
-using MeasurementModelFuncRef = std::function<Eigen::VectorXf(const Eigen::VectorXf, const Eigen::VectorXf)>;
-using JacobianFuncRef = std::function<Eigen::MatrixXf(const Eigen::VectorXf, const Eigen::VectorXf)>;
-using SensorNoiseFuncRef = std::function<Eigen::MatrixXf(const Eigen::VectorXf, const Eigen::VectorXf)>;
+using DynamicModelFuncRef = std::function<Eigen::VectorXd(const Eigen::VectorXd, const Eigen::VectorXd)>;
+using MeasurementModelFuncRef = std::function<Eigen::VectorXd(const Eigen::VectorXd, const Eigen::VectorXd)>;
+using JacobianFuncRef = std::function<Eigen::MatrixXd(const Eigen::VectorXd, const Eigen::VectorXd)>;
+using SensorNoiseFuncRef = std::function<Eigen::MatrixXd(const Eigen::VectorXd, const Eigen::VectorXd)>;
 
 // TODO: make sure this does not allocate mem on the heap.
 
@@ -28,55 +28,55 @@ public:
 
 protected:
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> kalman_update(Eigen::VectorXf x,
-                                                             Eigen::VectorXf h,
-                                                             Eigen::VectorXf y,
-                                                             Eigen::MatrixXf C,
-                                                             Eigen::MatrixXf R,
-                                                             Eigen::MatrixXf S,
-                                                             Eigen::MatrixXf P);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> kalman_update(Eigen::VectorXd x,
+                                                             Eigen::VectorXd h,
+                                                             Eigen::VectorXd y,
+                                                             Eigen::MatrixXd C,
+                                                             Eigen::MatrixXd R,
+                                                             Eigen::MatrixXd S,
+                                                             Eigen::MatrixXd P);
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> measurement_update(Eigen::VectorXf x,
-                                                                  Eigen::VectorXf inputs,
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> measurement_update(Eigen::VectorXd x,
+                                                                  Eigen::VectorXd inputs,
                                                                   MeasurementModelFuncRef measurement_model,
-                                                                  Eigen::VectorXf y,
+                                                                  Eigen::VectorXd y,
                                                                   JacobianFuncRef measurement_jacobian,
                                                                   SensorNoiseFuncRef sensor_noise_model,
-                                                                  Eigen::MatrixXf P);
+                                                                  Eigen::MatrixXd P);
   
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> calculate_measurement_update(Eigen::VectorXf x,
-                                                                            Eigen::VectorXf inputs,
-                                                                            Eigen::MatrixXf h,
-                                                                            Eigen::VectorXf y,
-                                                                            Eigen::MatrixXf C,
-                                                                            Eigen::MatrixXf R,
-                                                                            Eigen::MatrixXf P);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> calculate_measurement_update(Eigen::VectorXd x,
+                                                                            Eigen::VectorXd inputs,
+                                                                            Eigen::MatrixXd h,
+                                                                            Eigen::VectorXd y,
+                                                                            Eigen::MatrixXd C,
+                                                                            Eigen::MatrixXd R,
+                                                                            Eigen::MatrixXd P);
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> propagate_model(Eigen::VectorXf x,
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> propagate_model(Eigen::VectorXd x,
                                                                DynamicModelFuncRef dynamic_model,
                                                                JacobianFuncRef jacobian,
-                                                               Eigen::VectorXf inputs,
+                                                               Eigen::VectorXd inputs,
                                                                JacobianFuncRef input_jacobian,
-                                                               Eigen::MatrixXf P,
-                                                               Eigen::MatrixXf Q,
-                                                               Eigen::MatrixXf Q_g,
-                                                               float Ts);          
+                                                               Eigen::MatrixXd P,
+                                                               Eigen::MatrixXd Q,
+                                                               Eigen::MatrixXd Q_g,
+                                                               double Ts);
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> single_measurement_update(float measurement,
-                                                                         float measurement_prediction,
-                                                                         float measurement_uncertainty,
-                                                                         Eigen::VectorXf measurement_jacobian,
-                                                                         Eigen::VectorXf x,
-                                                                         Eigen::MatrixXf P);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> single_measurement_update(double measurement,
+                                                                         double measurement_prediction,
+                                                                         double measurement_uncertainty,
+                                                                         Eigen::VectorXd measurement_jacobian,
+                                                                         Eigen::VectorXd x,
+                                                                         Eigen::MatrixXd P);
   
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> partial_measurement_update(Eigen::VectorXf x,
-                                                                        Eigen::VectorXf inputs,
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> partial_measurement_update(Eigen::VectorXd x,
+                                                                        Eigen::VectorXd inputs,
                                                                         MeasurementModelFuncRef measurement_model,
-                                                                        Eigen::VectorXf y,
+                                                                        Eigen::VectorXd y,
                                                                         JacobianFuncRef measurement_jacobian,
                                                                         SensorNoiseFuncRef sensor_noise_model,
-                                                                        Eigen::MatrixXf P,
-                                                                        Eigen::VectorXf gammas);
+                                                                        Eigen::MatrixXd P,
+                                                                        Eigen::VectorXd gammas);
 
 private:
   virtual void estimate(const Input & input, Output & output) override = 0;

--- a/roscopter/include/ekf/estimator_ekf.hpp
+++ b/roscopter/include/ekf/estimator_ekf.hpp
@@ -6,7 +6,6 @@
 #include <tuple>
 
 #include <Eigen/Geometry>
-#include <yaml-cpp/yaml.h>
 
 #include "estimator_ros.hpp"
 

--- a/roscopter/include/ekf/estimator_ros.hpp
+++ b/roscopter/include/ekf/estimator_ros.hpp
@@ -33,8 +33,8 @@
 
 #include "param_manager/param_manager.hpp"
 
-#define EARTH_RADIUS 6378145.0f
-#define NOT_IN_USE -1000000.f
+#define EARTH_RADIUS 6378145.0
+#define NOT_IN_USE -1000000.0
 #define MILLIS_TO_NANOS 1000000
 
 using std::placeholders::_1;
@@ -51,15 +51,15 @@ public:
 protected:
   struct Input // FIXME: there are inputs that are not in this struct.
   {
-    float gyro_x;
-    float gyro_y;
-    float gyro_z;
-    float accel_x;
-    float accel_y;
-    float accel_z;
+    double gyro_x;
+    double gyro_y;
+    double gyro_z;
+    double accel_x;
+    double accel_y;
+    double accel_z;
     bool baro_new;
-    float static_pres;
-    float diff_pres;
+    double static_pres;
+    double diff_pres;
     bool gps_new;
     int gps_yday;
     int gps_year;
@@ -68,40 +68,40 @@ protected:
     double gps_lat;
     double gps_lon;
     double gps_alt;
-    float gps_n;
-    float gps_e;
-    float gps_h;
-    float gps_vg;
-    float gps_vn;
-    float gps_ve;
-    float gps_vd;
-    float gps_course;
+    double gps_n;
+    double gps_e;
+    double gps_h;
+    double gps_vg;
+    double gps_vn;
+    double gps_ve;
+    double gps_vd;
+    double gps_course;
     bool status_armed;
     bool armed_init;
     bool mag_new;
-    float mag_x;
-    float mag_y;
-    float mag_z;
+    double mag_x;
+    double mag_y;
+    double mag_z;
   };
 
   struct Output
   {
-    float pn = 0.0f;
-    float pe = 0.0f;
-    float pd = 0.0f;
-    float vx = 0.0f;
-    float vy = 0.0f;
-    float vz = 0.0f;
-    float phi = 0.0f;
-    float theta = 0.0f;
-    float psi = 0.0f;
-    float bx = 0.0f;
-    float by = 0.0f;
-    float bz = 0.0f;
-    float p = 0.0f;
-    float q = 0.0f;
-    float r = 0.0f;
-    Eigen::Quaternionf quat = Eigen::Quaternionf(1.0f, 0.0f, 0.0f, 0.0f);
+    double pn = 0.0;
+    double pe = 0.0;
+    double pd = 0.0;
+    double vx = 0.0;
+    double vy = 0.0;
+    double vz = 0.0;
+    double phi = 0.f;
+    double theta = 0.0;
+    double psi = 0.0;
+    double bx = 0.0;
+    double by = 0.0;
+    double bz = 0.0;
+    double p = 0.0;
+    double q = 0.0;
+    double r = 0.0;
+    Eigen::Quaterniond quat = Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0);
   };
 
   bool init_conds_saved_ = false;
@@ -109,7 +109,7 @@ protected:
 
   bool baro_init_ = false;
   
-  float rho_;
+  double rho_;
   
   /**
    * @brief Indicates if the magnetometer magnetic field parameters have been initialized.
@@ -126,8 +126,8 @@ protected:
   bool has_fix_ = false;
   double init_lat_ = 0.0;                 /**< Initial latitude in degrees */
   double init_lon_ = 0.0;                 /**< Initial longitude in degrees */
-  float init_alt_ = 0.0;                  /**< Initial altitude in meters above MSL  */
-  float init_static_;                     /**< Initial static pressure (mbar)  */
+  double init_alt_ = 0.0;                  /**< Initial altitude in meters above MSL  */
+  double init_static_;                     /**< Initial static pressure (mbar)  */
   
   std::unordered_map<std::string, rclcpp::Time> time_since_last_sensor_update_;
   void set_sensor_monitoring();
@@ -163,7 +163,7 @@ private:
   bool gps_new_;
   bool armed_first_time_;                 /**< Arm before starting estimation  */
   int baro_count_;                        /**< Used to grab the first set of baro measurements */
-  std::vector<float> init_static_vector_; /**< Used to grab the first set of baro measurements */
+  std::vector<double> init_static_vector_; /**< Used to grab the first set of baro measurements */
 
   /**
    * This declares each parameter as a parameter so that the ROS2 parameter system can recognize each parameter.

--- a/roscopter/include/ekf/estimator_ros.hpp
+++ b/roscopter/include/ekf/estimator_ros.hpp
@@ -14,7 +14,6 @@
 #include <chrono>
 #include <unordered_map>
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>

--- a/roscopter/include/ekf/estimator_ros.hpp
+++ b/roscopter/include/ekf/estimator_ros.hpp
@@ -12,23 +12,17 @@
 #define ESTIMATOR_ROS_H
 
 #include <chrono>
+#include <filesystem>
 #include <unordered_map>
 
-#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/barometer.hpp>
 #include <rosflight_msgs/msg/status.hpp>
 #include <rosflight_msgs/msg/gnss.hpp>
-#include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <roscopter_msgs/msg/state.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
-
-#include <cstdlib>
-#include <cstring>
-#include <filesystem>
-#include <fstream>
 
 #include "param_manager/param_manager.hpp"
 

--- a/roscopter/include/navigation/path_manager.hpp
+++ b/roscopter/include/navigation/path_manager.hpp
@@ -1,15 +1,12 @@
 #ifndef PATH_MANAGER_H
 #define PATH_MANAGER_H
 
-#include <algorithm>
-#include <vector>
-#include <cmath>
+#include <Eigen/Core>
+
+#include <roscopter_msgs/msg/waypoint.hpp>
+#include <roscopter_msgs/msg/trajectory_command.hpp>
 
 #include "navigation/path_manager_ros.hpp"
-#include "roscopter_msgs/msg/waypoint.hpp"
-#include "roscopter_msgs/msg/trajectory_command.hpp"
-
-#include <Eigen/Core>
 
 namespace roscopter {
 

--- a/roscopter/include/navigation/path_manager_ros.hpp
+++ b/roscopter/include/navigation/path_manager_ros.hpp
@@ -1,19 +1,18 @@
 #ifndef PATH_MANAGER_ROS_H
 #define PATH_MANAGER_ROS_H
 
+#include <chrono>
+#include <vector>
+
 #include <rclcpp/rclcpp.hpp>
 
-#include "roscopter_msgs/msg/waypoint.hpp"
-#include "roscopter_msgs/msg/trajectory_command.hpp"
-#include "roscopter_msgs/msg/state.hpp"
+#include <roscopter_msgs/msg/waypoint.hpp>
+#include <roscopter_msgs/msg/trajectory_command.hpp>
+#include <roscopter_msgs/msg/state.hpp>
 
-#include "std_srvs/srv/trigger.hpp"
+#include <std_srvs/srv/trigger.hpp>
 
 #include "param_manager/param_manager.hpp"
-
-#include <stdint.h>
-#include <vector>
-#include <chrono>
 
 using std::placeholders::_1;
 

--- a/roscopter/include/navigation/path_planner.hpp
+++ b/roscopter/include/navigation/path_planner.hpp
@@ -1,17 +1,15 @@
 #ifndef PATH_PLANNER_HPP
 #define PATH_PLANNER_HPP
 
-#include <cmath>
-
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
-#include <yaml-cpp/yaml.h>
+
+#include <roscopter_msgs/msg/state.hpp>
+#include <roscopter_msgs/msg/waypoint.hpp>
+#include <roscopter_msgs/srv/add_waypoint.hpp>
+#include <rosflight_msgs/srv/param_file.hpp>
 
 #include "param_manager/param_manager.hpp"
-#include "roscopter_msgs/msg/state.hpp"
-#include "roscopter_msgs/msg/waypoint.hpp"
-#include "roscopter_msgs/srv/add_waypoint.hpp"
-#include "rosflight_msgs/srv/param_file.hpp"
 
 #define EARTH_RADIUS 6378145.0f
 

--- a/roscopter/include/navigation/trajectory_follower.hpp
+++ b/roscopter/include/navigation/trajectory_follower.hpp
@@ -1,8 +1,6 @@
 #ifndef TRAJECTORY_FOLLOWER_HPP
 #define TRAJECTORY_FOLLOWER_HPP
 
-#include <stdint.h>
-
 #include <Eigen/Geometry>
 
 #include "navigation/trajectory_follower_ros.hpp"

--- a/roscopter/include/navigation/trajectory_follower_ros.hpp
+++ b/roscopter/include/navigation/trajectory_follower_ros.hpp
@@ -1,16 +1,15 @@
 #ifndef TRAJECTORY_FOLLOWER_ROS_H
 #define TRAJECTORY_FOLLOWER_ROS_H
 
-#include <stdint.h>
-
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
+#include <roscopter_msgs/msg/controller_command.hpp>
+#include <roscopter_msgs/msg/trajectory_command.hpp>
+#include <roscopter_msgs/msg/state.hpp>
+#include <rosflight_msgs/msg/status.hpp>
+
 #include "param_manager/param_manager.hpp"
-#include "roscopter_msgs/msg/controller_command.hpp"
-#include "roscopter_msgs/msg/trajectory_command.hpp"
-#include "roscopter_msgs/msg/state.hpp"
-#include "rosflight_msgs/msg/status.hpp"
 
 using std::placeholders::_1;
 

--- a/roscopter/launch/roscopter.launch.py
+++ b/roscopter/launch/roscopter.launch.py
@@ -1,15 +1,13 @@
-import os
-import sys
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
-    roscopter_dir = get_package_share_directory('roscopter')
-    controller_param_file = os.path.join(roscopter_dir, 'params', 'multirotor.yaml')
-    estimator_param_file = os.path.join(roscopter_dir, 'params', 'estimator.yaml')
+    roscopter_share = FindPackageShare('roscopter')
+    controller_param_file = PathJoinSubstitution([roscopter_share, 'params', 'multirotor.yaml'])
+    estimator_param_file = PathJoinSubstitution([roscopter_share, 'params', 'estimator.yaml'])
     
     hotstart_estimator_arg = DeclareLaunchArgument(
         "hotstart_estimator",

--- a/roscopter/package.xml
+++ b/roscopter/package.xml
@@ -19,7 +19,8 @@
   <depend>rclpy</depend>
   <depend>roscopter_msgs</depend>
   <depend>rosflight_msgs</depend>
-  <depend>tf2</depend>
+  <depend>rosflight_compat</depend>
+  <depend>ament_index_cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/roscopter/src/ekf/estimator_continuous_discrete.cpp
+++ b/roscopter/src/ekf/estimator_continuous_discrete.cpp
@@ -244,7 +244,7 @@ Eigen::VectorXd EstimatorContinuousDiscrete::dynamics(const Eigen::VectorXd& sta
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs)
 {
-  Eigen::Vector3d accel = inputs.block<3,1>(0,0);
+  [[maybe_unused]] Eigen::Vector3d accel = inputs.block<3,1>(0,0);
   Eigen::Vector3d gyro = inputs.block<3,1>(3,0);
   
   Eigen::Vector3d vels = state.block<3,1>(3,0);
@@ -275,7 +275,7 @@ return A;
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::input_jacobian(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& inputs)
+  const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& inputs)
 {
   // This uses both the accel and gyro. The associated jacobians have been combined.
   Eigen::Matrix<double, num_states, 6> G = Eigen::Matrix<double, num_states, num_estimator_inputs>::Zero();
@@ -296,7 +296,7 @@ Eigen::MatrixXd EstimatorContinuousDiscrete::input_jacobian(
 
 
 Eigen::VectorXd EstimatorContinuousDiscrete::tilt_mag_measurement_prediction(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Vector<double, num_tilt_mag_measurements> h = Eigen::Vector<double, num_tilt_mag_measurements>::Zero();
 
@@ -306,7 +306,7 @@ Eigen::VectorXd EstimatorContinuousDiscrete::tilt_mag_measurement_prediction(
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::tilt_mag_measurement_jacobian(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  [[maybe_unused]] const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Matrix<double, num_tilt_mag_measurements, num_states> C = Eigen::Matrix<double, num_tilt_mag_measurements, num_states>::Zero();
   
@@ -377,7 +377,7 @@ Eigen::MatrixXd EstimatorContinuousDiscrete::del_tilt_mag_del_states(const Eigen
 // ======== BARO MEAUREMENT STEP EQUATIONS========
 // These are passed by reference to the baro measurement update step.
 Eigen::VectorXd EstimatorContinuousDiscrete::baro_measurement_prediction(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   double gravity = params_.get_double("gravity");
 
@@ -390,7 +390,7 @@ Eigen::VectorXd EstimatorContinuousDiscrete::baro_measurement_prediction(
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_jacobian(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  [[maybe_unused]] const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   double gravity = params_.get_double("gravity");
 
@@ -403,7 +403,7 @@ Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_jacobian(
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_sensor_noise(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  [[maybe_unused]] const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Matrix<double, num_baro_measurements, num_baro_measurements> R;
 
@@ -415,7 +415,7 @@ Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_sensor_noise(
 // ======== GNSS MEAUREMENT STEP EQUATIONS========
 // These are passed by reference to the GNSS measurement update step.
 Eigen::VectorXd EstimatorContinuousDiscrete::gnss_measurement_prediction(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Vector<double, num_gnss_measurements> h = Eigen::Vector<double, num_gnss_measurements>::Zero();
 
@@ -449,7 +449,7 @@ Eigen::VectorXd EstimatorContinuousDiscrete::gnss_measurement_prediction(
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::gnss_measurement_jacobian(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Matrix<double, num_gnss_measurements, num_states> C = Eigen::Matrix<double, num_gnss_measurements, num_states>::Zero();
   Eigen::Vector3d vels = state.block<3,1>(3,0);
@@ -473,7 +473,7 @@ Eigen::MatrixXd EstimatorContinuousDiscrete::gnss_measurement_jacobian(
 }
 
 Eigen::MatrixXd EstimatorContinuousDiscrete::gnss_measurement_sensor_noise(
-  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
+  [[maybe_unused]] const Eigen::VectorXd& state, [[maybe_unused]] const Eigen::VectorXd& input)
 {
   Eigen::Matrix<double, num_gnss_measurements, num_gnss_measurements> R;
 
@@ -776,7 +776,7 @@ void EstimatorContinuousDiscrete::update_measurement_model_parameters()
   // For readability, declare the parameters used in the function here
   double sigma_n_gps = params_.get_double("sigma_n_gps");
   double sigma_e_gps = params_.get_double("sigma_e_gps");
-  double sigma_h_gps = params_.get_double("sigma_h_gps");
+  [[maybe_unused]] double sigma_h_gps = params_.get_double("sigma_h_gps");
   double sigma_vn_gps = params_.get_double("sigma_vn_gps");
   double sigma_ve_gps = params_.get_double("sigma_ve_gps");
   double sigma_vd_gps = params_.get_double("sigma_vd_gps");

--- a/roscopter/src/ekf/estimator_continuous_discrete.cpp
+++ b/roscopter/src/ekf/estimator_continuous_discrete.cpp
@@ -1,7 +1,8 @@
+#include <cmath>
+
 #include "ekf/estimator_continuous_discrete.hpp"
 #include "ekf/estimator_ros.hpp"
 #include "ekf/geomag.h"
-#include <cmath>
 
 namespace roscopter
 {

--- a/roscopter/src/ekf/estimator_continuous_discrete.cpp
+++ b/roscopter/src/ekf/estimator_continuous_discrete.cpp
@@ -7,7 +7,7 @@ namespace roscopter
 {
 
 // ======== UTILITY FUNCTIONS ========
-float radians(float degrees) { return M_PI * degrees / 180.0; }
+double radians(double degrees) { return M_PI * degrees / 180.0; }
 
 double wrap_within_180(double fixed_heading, double wrapped_heading)
 {
@@ -15,10 +15,10 @@ double wrap_within_180(double fixed_heading, double wrapped_heading)
   return wrapped_heading - floor((wrapped_heading - fixed_heading) / (2 * M_PI) + 0.5) * 2 * M_PI;
 }
 
-Eigen::Matrix3f skew_matrix(Eigen::Vector3f vec)
+Eigen::Matrix3d skew_matrix(Eigen::Vector3d vec)
 {
 
-  Eigen::Matrix3f skew_symmetric_matrix;
+  Eigen::Matrix3d skew_symmetric_matrix;
 
   skew_symmetric_matrix << 0.0, -vec(2), vec(1),
                            vec(2), 0.0, -vec(0),
@@ -30,14 +30,14 @@ Eigen::Matrix3f skew_matrix(Eigen::Vector3f vec)
 // ======== CONSTRUCTOR ========
 EstimatorContinuousDiscrete::EstimatorContinuousDiscrete()
     : EstimatorEKF()
-    , xhat_(Eigen::Vector<float, num_states>::Zero())
-    , P_(Eigen::Matrix<float, num_states, num_states>::Identity())
-    , Q_(Eigen::Matrix<float, num_states, num_states>::Identity())
-    , Q_inputs_(Eigen::Matrix<float, num_estimator_inputs, num_estimator_inputs>::Identity())
-    , R_gnss_(Eigen::Matrix<float, num_gnss_measurements, num_gnss_measurements>::Zero())
-    , R_mag_(Eigen::Matrix<float,num_mag_measurements, num_mag_measurements>::Zero())
-    , R_tilt_(Eigen::Matrix<float,num_tilt_mag_measurements, num_tilt_mag_measurements>::Zero())
-    , R_baro_(Eigen::Matrix<float,num_baro_measurements, num_baro_measurements>::Zero())
+    , xhat_(Eigen::Vector<double, num_states>::Zero())
+    , P_(Eigen::Matrix<double, num_states, num_states>::Identity())
+    , Q_(Eigen::Matrix<double, num_states, num_states>::Identity())
+    , Q_inputs_(Eigen::Matrix<double, num_estimator_inputs, num_estimator_inputs>::Identity())
+    , R_gnss_(Eigen::Matrix<double, num_gnss_measurements, num_gnss_measurements>::Zero())
+    , R_tilt_(Eigen::Matrix<double,num_tilt_mag_measurements, num_tilt_mag_measurements>::Zero())
+    , R_mag_(Eigen::Matrix<double,num_mag_measurements, num_mag_measurements>::Zero())
+    , R_baro_(Eigen::Matrix<double,num_baro_measurements, num_baro_measurements>::Zero())
 {
   // This binds the various functions for the measurement and dynamic models and their jacobians,
   // to a reference that is efficient to pass to the functions used to do the estimation.
@@ -64,7 +64,7 @@ EstimatorContinuousDiscrete::EstimatorContinuousDiscrete()
 void EstimatorContinuousDiscrete::init_state(const Input & input)
 {
   if (mag_init_ && input.mag_new) {
-    float heading = -atan2f(input.mag_y, input.mag_x);
+    double heading = -atan2(input.mag_y, input.mag_x);
     heading += radians(declination_);
     xhat_(8) = heading;
     state_init_ = true;
@@ -100,7 +100,7 @@ void EstimatorContinuousDiscrete::estimate(const Input & input, Output & output)
   check_sensors();
   check_estimate(input);
   
-  Eigen::Vector3f mag;
+  Eigen::Vector3d mag;
   mag << input.mag_x, input.mag_y, input.mag_z;
   mag /= mag.norm();
   
@@ -125,11 +125,11 @@ void EstimatorContinuousDiscrete::estimate(const Input & input, Output & output)
   double psi2 = output.psi/2;
   double theta2 = output.theta/2;
   double phi2 = output.phi/2;
-  double qw = cosf(psi2)*cosf(theta2)*cosf(phi2) + sinf(psi2)*sinf(theta2)*sinf(phi2);
-  double qx = cosf(psi2)*cosf(theta2)*sinf(phi2) - sinf(psi2)*sinf(theta2)*cosf(phi2);
-  double qy = cosf(psi2)*sinf(theta2)*cosf(phi2) + sinf(psi2)*cosf(theta2)*sinf(phi2);
-  double qz = sinf(psi2)*cosf(theta2)*cosf(phi2) - cosf(psi2)*sinf(theta2)*sinf(phi2);
-  output.quat = Eigen::Quaternionf(qw, qx, qy, qz);
+  double qw = cos(psi2)*cos(theta2)*cos(phi2) + sin(psi2)*sin(theta2)*sin(phi2);
+  double qx = cos(psi2)*cos(theta2)*sin(phi2) - sin(psi2)*sin(theta2)*cos(phi2);
+  double qy = cos(psi2)*sin(theta2)*cos(phi2) + sin(psi2)*cos(theta2)*sin(phi2);
+  double qz = sin(psi2)*cos(theta2)*cos(phi2) - cos(psi2)*sin(theta2)*sin(phi2);
+  output.quat = Eigen::Quaterniond(qw, qx, qy, qz);
 }
 
 // ======== ESTIMATION LOOP STEPS ========
@@ -138,7 +138,7 @@ void EstimatorContinuousDiscrete::prediction_step(const Input& input)
   double frequency = params_.get_double("estimator_update_frequency");
   double Ts = 1.0 / frequency;
 
-  Eigen::Vector<float, num_estimator_inputs> imu_measurements; // These are the input to the propagation.
+  Eigen::Vector<double, num_estimator_inputs> imu_measurements; // These are the input to the propagation.
   imu_measurements << input.accel_x, input.accel_y, input.accel_z,
                       input.gyro_x, input.gyro_y, input.gyro_z;
 
@@ -161,25 +161,25 @@ void EstimatorContinuousDiscrete::mag_measurement_update_step(const Input& input
 
   bool convert_to_gauss = params_.get_bool("convert_to_gauss");
 
-  Eigen::Vector3f mag_readings;
+  Eigen::Vector3d mag_readings;
   mag_readings << input.mag_x, input.mag_y, input.mag_z;
   if (convert_to_gauss) {
     mag_readings *= 10'000.;
   }
   
-  Eigen::Vector<float, num_mag_measurements> y_mag;
+  Eigen::Vector<double, num_mag_measurements> y_mag;
   y_mag << mag_readings/mag_readings.norm();
 
-  Eigen::Vector3f Theta = xhat_.block<3,1>(6,0); // Theta is the vector of the euler angles.
+  Eigen::Vector3d Theta = xhat_.block<3,1>(6,0); // Theta is the vector of the euler angles.
   Theta(2) = 0.0;
   y_mag = R(Theta)*y_mag;
   
-  Eigen::Vector<float, num_tilt_mag_measurements> y_heading;
-  y_heading << -atan2f(y_mag(1), y_mag(0)) + radians(declination_);
+  Eigen::Vector<double, num_tilt_mag_measurements> y_heading;
+  y_heading << -atan2(y_mag(1), y_mag(0)) + radians(declination_);
 
   y_heading(0) = wrap_within_180(xhat_(8), y_heading(0));
 
-  Eigen::Vector<float, 2 + num_mag_measurements> mag_info;
+  Eigen::Vector<double, 2 + num_mag_measurements> mag_info;
   mag_info << radians(declination_), radians(inclination_), y_mag;
 
   std::tie(P_, xhat_) = measurement_update(xhat_, mag_info, tilt_mag_measurement_model, y_heading, tilt_mag_measurement_jacobian_model, tilt_mag_measurement_sensor_noise_model, P_);
@@ -192,10 +192,10 @@ void EstimatorContinuousDiscrete::baro_measurement_update_step(const Input& inpu
     return;
   }
 
-  Eigen::Vector<float, num_baro_measurements> y_baro;
+  Eigen::Vector<double, num_baro_measurements> y_baro;
   y_baro << input.static_pres;
 
-  Eigen::Vector<float, 1> _;
+  Eigen::Vector<double, 1> _{0};
 
   std::tie(P_, xhat_) = measurement_update(xhat_, _, baro_measurement_model, y_baro,
                                              baro_measurement_jacobian_model, baro_measurement_sensor_noise_model, P_);
@@ -203,12 +203,12 @@ void EstimatorContinuousDiscrete::baro_measurement_update_step(const Input& inpu
 
 void EstimatorContinuousDiscrete::gnss_measurement_update_step(const Input& input)
 {
-  Eigen::Vector<float, 1> _; // This is used when no inputs are needed.
+  Eigen::Vector<double, 1> _{0}; // This is used when no inputs are needed.
 
   // Only update if new GPS information is available.
   if (input.gps_new && gps_init_) {
     // Measurements for the positional states.
-    Eigen::Vector<float, num_gnss_measurements> y_gps;
+    Eigen::Vector<double, num_gnss_measurements> y_gps;
     y_gps << input.gps_n, input.gps_e, input.gps_vn, input.gps_ve, input.gps_vd;
   
     std::tie(P_, xhat_) = measurement_update(xhat_, _, gnss_measurement_model, y_gps,
@@ -218,40 +218,40 @@ void EstimatorContinuousDiscrete::gnss_measurement_update_step(const Input& inpu
 
 // ======== PREDICITON STEP EQUATIONS ========
 // These are passed by reference to the predition step.
-Eigen::VectorXf EstimatorContinuousDiscrete::dynamics(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs)
+Eigen::VectorXd EstimatorContinuousDiscrete::dynamics(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs)
 {
 
   double gravity = params_.get_double("gravity");
   
   // Unpack states and inputs.
-  Eigen::Vector3f vels = state.block<3,1>(3,0);
-  Eigen::Vector3f Theta = state.block<3,1>(6,0); // Theta is the vector of the euler angles.
-  Eigen::Vector3f biases = state.block<3,1>(9,0);
+  Eigen::Vector3d vels = state.block<3,1>(3,0);
+  Eigen::Vector3d Theta = state.block<3,1>(6,0); // Theta is the vector of the euler angles.
+  Eigen::Vector3d biases = state.block<3,1>(9,0);
 
-  Eigen::Vector3f y_accel = inputs.block<3,1>(0,0);
-  Eigen::Vector3f y_gyro = inputs.block<3,1>(3,0);
+  Eigen::Vector3d y_accel = inputs.block<3,1>(0,0);
+  Eigen::Vector3d y_gyro = inputs.block<3,1>(3,0);
   
   // Calculate the derivatives of the states (see Chapter 14 of the UAVbook)
-  Eigen::Vector3f velocity_dot = R(Theta).transpose()*gravity*Eigen::Vector3f::UnitZ() + y_accel + vels.cross(y_gyro- biases);
-  Eigen::Vector3f euler_angles_dot = S(Theta)*(y_gyro - biases);
+  Eigen::Vector3d velocity_dot = R(Theta).transpose()*gravity*Eigen::Vector3d::UnitZ() + y_accel + vels.cross(y_gyro- biases);
+  Eigen::Vector3d euler_angles_dot = S(Theta)*(y_gyro - biases);
   
   // Stuff the derivative vector with the respective derivatives.
-  Eigen::Vector<float, num_states> f = Eigen::Vector<float, num_states>::Zero();
+  Eigen::Vector<double, num_states> f = Eigen::Vector<double, num_states>::Zero();
   f << R(Theta)*vels, velocity_dot, euler_angles_dot;
 
   return f;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs)
+Eigen::MatrixXd EstimatorContinuousDiscrete::jacobian(const Eigen::VectorXd& state, const Eigen::VectorXd& inputs)
 {
-  Eigen::Vector3f accel = inputs.block<3,1>(0,0);
-  Eigen::Vector3f gyro = inputs.block<3,1>(3,0);
+  Eigen::Vector3d accel = inputs.block<3,1>(0,0);
+  Eigen::Vector3d gyro = inputs.block<3,1>(3,0);
   
-  Eigen::Vector3f vels = state.block<3,1>(3,0);
-  Eigen::Vector3f Theta = state.block<3,1>(6,0);
-  Eigen::Vector3f biases = state.block<3,1>(9,0);
+  Eigen::Vector3d vels = state.block<3,1>(3,0);
+  Eigen::Vector3d Theta = state.block<3,1>(6,0);
+  Eigen::Vector3d biases = state.block<3,1>(9,0);
 
-  Eigen::Matrix<float, num_states, num_states> A = Eigen::Matrix<float, num_states, num_states>::Zero();
+  Eigen::Matrix<double, num_states, num_states> A = Eigen::Matrix<double, num_states, num_states>::Zero();
 
   // Identity matrix.
   A.block<3,3>(0,3) = R(Theta);
@@ -274,15 +274,16 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::jacobian(const Eigen::VectorXf& sta
 return A;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::input_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& inputs)
+Eigen::MatrixXd EstimatorContinuousDiscrete::input_jacobian(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& inputs)
 {
   // This uses both the accel and gyro. The associated jacobians have been combined.
-  Eigen::Matrix<float, num_states, 6> G = Eigen::Matrix<float, num_states, num_estimator_inputs>::Zero();
+  Eigen::Matrix<double, num_states, 6> G = Eigen::Matrix<double, num_states, num_estimator_inputs>::Zero();
   
-  Eigen::Vector3f Theta = state.block<3,1>(6,0);
-  Eigen::Vector3f vels = state.block<3,1>(3,0);
+  Eigen::Vector3d Theta = state.block<3,1>(6,0);
+  Eigen::Vector3d vels = state.block<3,1>(3,0);
   
-  G.block<3,3>(3,0) = -Eigen::Matrix3f::Identity();
+  G.block<3,3>(3,0) = -Eigen::Matrix3d::Identity();
 
   G.block<3,3>(3,3) = -skew_matrix(vels);
   G.block<3,3>(6,3) = -S(Theta);
@@ -294,18 +295,20 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::input_jacobian(const Eigen::VectorX
 // These are passed by reference to the mag measurement update step.
 
 
-Eigen::VectorXf EstimatorContinuousDiscrete::tilt_mag_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::VectorXd EstimatorContinuousDiscrete::tilt_mag_measurement_prediction(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Vector<float, num_tilt_mag_measurements> h = Eigen::Vector<float, num_tilt_mag_measurements>::Zero();
+  Eigen::Vector<double, num_tilt_mag_measurements> h = Eigen::Vector<double, num_tilt_mag_measurements>::Zero();
 
   h(0) = state(8);
 
   return h;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::tilt_mag_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::tilt_mag_measurement_jacobian(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_states> C = Eigen::Matrix<float, num_tilt_mag_measurements, num_states>::Zero();
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_states> C = Eigen::Matrix<double, num_tilt_mag_measurements, num_states>::Zero();
   
   // Magnetometer update
   C(0,8) = 1.0;
@@ -313,35 +316,35 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::tilt_mag_measurement_jacobian(const
   return C;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::tilt_mag_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::tilt_mag_measurement_sensor_noise(const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_tilt_mag_measurements> R;
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_tilt_mag_measurements> R;
 
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_states> G_state = del_tilt_mag_del_states(input, state);
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_states> G_state = del_tilt_mag_del_states(input, state);
 
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_mag_measurements> G_mag = del_tilt_mag_del_mag(input, state);
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_mag_measurements> G_mag = del_tilt_mag_del_mag(input, state);
 
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_states> C = tilt_mag_measurement_jacobian(input, state);
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_states> C = tilt_mag_measurement_jacobian(input, state);
 
   R = G_mag*R_mag_*G_mag.transpose() + G_state*P_*G_state.transpose() - 2*G_state*P_*C.transpose() + R_tilt_;
 
   return R;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::del_tilt_mag_del_mag(const Eigen::VectorXf& y_mag, const Eigen::VectorXf& state)
+Eigen::MatrixXd EstimatorContinuousDiscrete::del_tilt_mag_del_mag(const Eigen::VectorXd& y_mag, const Eigen::VectorXd& state)
 {
-  float mx = y_mag(2);
-  float my = y_mag(3);
-  float mz = y_mag(4);
+  double mx = y_mag(2);
+  double my = y_mag(3);
+  double mz = y_mag(4);
 
-  float s_phi = sinf(state(6));
-  float s_theta = sinf(state(7));
-  float c_phi = cosf(state(6));
-  float c_theta = cosf(state(7));
+  double s_phi = sin(state(6));
+  double s_theta = sin(state(7));
+  double c_phi = cos(state(6));
+  double c_theta = cos(state(7));
 
-  float den = powf(my*c_phi - mz*s_phi,2) + powf(mx*c_theta + my*s_phi*s_theta + mz*s_theta*c_phi, 2);
+  double den = pow(my*c_phi - mz*s_phi,2) + pow(mx*c_theta + my*s_phi*s_theta + mz*s_theta*c_phi, 2);
   
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_mag_measurements> G;
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_mag_measurements> G;
 
   G(0,0) = (my*c_phi - mz*s_phi)*c_theta/den;
   G(0,1) = -(mx*c_phi*c_theta + mz*s_theta)/den;
@@ -350,20 +353,20 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::del_tilt_mag_del_mag(const Eigen::V
   return G;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::del_tilt_mag_del_states(const Eigen::VectorXf& y_mag, const Eigen::VectorXf& state)
+Eigen::MatrixXd EstimatorContinuousDiscrete::del_tilt_mag_del_states(const Eigen::VectorXd& y_mag, const Eigen::VectorXd& state)
 {
-  float mx = y_mag(2);
-  float my = y_mag(3);
-  float mz = y_mag(4);
+  double mx = y_mag(2);
+  double my = y_mag(3);
+  double mz = y_mag(4);
 
-  float s_phi = sinf(state(6));
-  float s_theta = sinf(state(7));
-  float c_phi = cosf(state(6));
-  float c_theta = cosf(state(7));
+  double s_phi = sin(state(6));
+  double s_theta = sin(state(7));
+  double c_phi = cos(state(6));
+  double c_theta = cos(state(7));
   
-  Eigen::Matrix<float, num_tilt_mag_measurements, num_states> G = Eigen::Matrix<float, num_tilt_mag_measurements, num_states>::Zero();
+  Eigen::Matrix<double, num_tilt_mag_measurements, num_states> G = Eigen::Matrix<double, num_tilt_mag_measurements, num_states>::Zero();
 
-  float den = powf(my*c_phi - mz*s_phi,2) + powf(mx*c_theta + my*s_phi*s_theta + mz*s_theta*c_phi, 2);
+  double den = pow(my*c_phi - mz*s_phi,2) + pow(mx*c_theta + my*s_phi*s_theta + mz*s_theta*c_phi, 2);
 
   G(0,6) = (mx*my*s_phi*c_theta + mx*mz*c_phi*c_theta + my*my*s_theta + mz*mz*s_theta)/den;
   G(0,7) =(my*c_phi - mz*s_phi)*(-mx*s_theta+ my*s_phi*c_theta + mz*c_phi*c_theta)/den;
@@ -373,11 +376,12 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::del_tilt_mag_del_states(const Eigen
 
 // ======== BARO MEAUREMENT STEP EQUATIONS========
 // These are passed by reference to the baro measurement update step.
-Eigen::VectorXf EstimatorContinuousDiscrete::baro_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::VectorXd EstimatorContinuousDiscrete::baro_measurement_prediction(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  float gravity = params_.get_double("gravity");
+  double gravity = params_.get_double("gravity");
 
-  Eigen::Vector<float, num_baro_measurements> h = Eigen::Vector<float, num_baro_measurements>::Zero();
+  Eigen::Vector<double, num_baro_measurements> h = Eigen::Vector<double, num_baro_measurements>::Zero();
 
   // Predicted static pressure measurement
   h(0) = -rho_*gravity*state(2);
@@ -385,11 +389,12 @@ Eigen::VectorXf EstimatorContinuousDiscrete::baro_measurement_prediction(const E
   return h;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::baro_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_jacobian(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  float gravity = params_.get_double("gravity");
+  double gravity = params_.get_double("gravity");
 
-  Eigen::Matrix<float, num_baro_measurements, num_states> C = Eigen::Matrix<float, num_baro_measurements, num_states>::Zero();
+  Eigen::Matrix<double, num_baro_measurements, num_states> C = Eigen::Matrix<double, num_baro_measurements, num_states>::Zero();
 
   // Static pressure
   C(0,2) = -rho_*gravity;
@@ -397,9 +402,10 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::baro_measurement_jacobian(const Eig
   return C;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::baro_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::baro_measurement_sensor_noise(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Matrix<float, num_baro_measurements, num_baro_measurements> R;
+  Eigen::Matrix<double, num_baro_measurements, num_baro_measurements> R;
 
   R = R_baro_;
 
@@ -408,9 +414,10 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::baro_measurement_sensor_noise(const
 
 // ======== GNSS MEAUREMENT STEP EQUATIONS========
 // These are passed by reference to the GNSS measurement update step.
-Eigen::VectorXf EstimatorContinuousDiscrete::gnss_measurement_prediction(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::VectorXd EstimatorContinuousDiscrete::gnss_measurement_prediction(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Vector<float, num_gnss_measurements> h = Eigen::Vector<float, num_gnss_measurements>::Zero();
+  Eigen::Vector<double, num_gnss_measurements> h = Eigen::Vector<double, num_gnss_measurements>::Zero();
 
   // North position
   h(0) = state(0);
@@ -420,10 +427,10 @@ Eigen::VectorXf EstimatorContinuousDiscrete::gnss_measurement_prediction(const E
   
   // Express body vels in the intertial frame.
   
-  Eigen::Vector3f inertial_vels;
+  Eigen::Vector3d inertial_vels;
   
-  Eigen::Vector3f vels = state.block<3,1>(3,0);
-  Eigen::Vector3f Theta = state.block<3,1>(6,0);
+  Eigen::Vector3d vels = state.block<3,1>(3,0);
+  Eigen::Vector3d Theta = state.block<3,1>(6,0);
 
   inertial_vels = R(Theta) * vels;
   
@@ -441,11 +448,12 @@ Eigen::VectorXf EstimatorContinuousDiscrete::gnss_measurement_prediction(const E
   return h;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::gnss_measurement_jacobian(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::gnss_measurement_jacobian(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Matrix<float, num_gnss_measurements, num_states> C = Eigen::Matrix<float, num_gnss_measurements, num_states>::Zero();
-  Eigen::Vector3f vels = state.block<3,1>(3,0);
-  Eigen::Vector3f Theta = state.block<3,1>(6,0);
+  Eigen::Matrix<double, num_gnss_measurements, num_states> C = Eigen::Matrix<double, num_gnss_measurements, num_states>::Zero();
+  Eigen::Vector3d vels = state.block<3,1>(3,0);
+  Eigen::Vector3d Theta = state.block<3,1>(6,0);
   
   // GPS north
   C(0,0) = 1;
@@ -464,9 +472,10 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::gnss_measurement_jacobian(const Eig
   return C;
 }
 
-Eigen::MatrixXf EstimatorContinuousDiscrete::gnss_measurement_sensor_noise(const Eigen::VectorXf& state, const Eigen::VectorXf& input)
+Eigen::MatrixXd EstimatorContinuousDiscrete::gnss_measurement_sensor_noise(
+  const Eigen::VectorXd& state, const Eigen::VectorXd& input)
 {
-  Eigen::Matrix<float, num_gnss_measurements, num_gnss_measurements> R;
+  Eigen::Matrix<double, num_gnss_measurements, num_gnss_measurements> R;
 
   R = R_gnss_;
 
@@ -474,67 +483,67 @@ Eigen::MatrixXf EstimatorContinuousDiscrete::gnss_measurement_sensor_noise(const
 }
 
 // ======== MEASUREMENT UPDATE HELPER FUNCTIONS========
-Eigen::Matrix3f EstimatorContinuousDiscrete::R(const Eigen::Vector3f& Theta)
+Eigen::Matrix3d EstimatorContinuousDiscrete::R(const Eigen::Vector3d& Theta)
 {
   // Finds rotation matrix from the inertial frame to the body frame using
   // RPY angles in the vector Theta.
-  float phi = Theta(0);
-  float theta = Theta(1);
-  float psi = Theta(2);
+  double phi = Theta(0);
+  double theta = Theta(1);
+  double psi = Theta(2);
 
-  Eigen::Matrix3f R_theta;
-  R_theta << cosf(psi)*cosf(theta), sinf(phi)*sinf(theta)*cosf(psi) - sinf(psi)*cosf(phi), sinf(phi)*sinf(psi) + sinf(theta)*cosf(phi)*cosf(psi),
-             sinf(psi)*cosf(theta), sinf(phi)*sinf(psi)*sinf(theta) + cosf(phi)*cosf(psi), - sinf(phi)*cosf(psi) + sinf(psi)*sinf(theta)*cosf(phi),
-             -sinf(theta), sinf(phi)*cosf(theta), cosf(phi)*cosf(theta);
+  Eigen::Matrix3d R_theta;
+  R_theta << cos(psi)*cos(theta), sin(phi)*sin(theta)*cos(psi) - sin(psi)*cos(phi), sin(phi)*sin(psi) + sin(theta)*cos(phi)*cos(psi),
+             sin(psi)*cos(theta), sin(phi)*sin(psi)*sin(theta) + cos(phi)*cos(psi), - sin(phi)*cos(psi) + sin(psi)*sin(theta)*cos(phi),
+             -sin(theta), sin(phi)*cos(theta), cos(phi)*cos(theta);
   return R_theta;
 }
 
-Eigen::Matrix3f EstimatorContinuousDiscrete::S(const Eigen::Vector3f& Theta)
+Eigen::Matrix3d EstimatorContinuousDiscrete::S(const Eigen::Vector3d& Theta)
 {
   // Finds transition matrix using RPY angles on the vector Theta. See chapter 14 of the UAVbook.
-  float phi = Theta(0);
-  float theta = Theta(1);
+  double phi = Theta(0);
+  double theta = Theta(1);
 
-  Eigen::Matrix3f S_theta;
-  S_theta << 1.0, sinf(phi)*tanf(theta), cosf(phi)*tanf(theta),
-             0.0, cosf(phi), -sinf(phi),
-             0.0, sinf(phi)/cosf(theta), cosf(phi)/cosf(theta);
+  Eigen::Matrix3d S_theta;
+  S_theta << 1.0, sin(phi)*tan(theta), cos(phi)*tan(theta),
+             0.0, cos(phi), -sin(phi),
+             0.0, sin(phi)/cos(theta), cos(phi)/cos(theta);
   return S_theta;
 }
 
-Eigen::Matrix3f EstimatorContinuousDiscrete::del_S_Theta_del_Theta(const Eigen::Vector3f& Theta, const Eigen::Vector3f& biases,
-                                                                   const Eigen::Vector3f& gyro)
+Eigen::Matrix3d EstimatorContinuousDiscrete::del_S_Theta_del_Theta(const Eigen::Vector3d& Theta, const Eigen::Vector3d& biases,
+                                                                   const Eigen::Vector3d& gyro)
 {
-  float bias_y = biases(1);
-  float bias_z = biases(2);
+  double bias_y = biases(1);
+  double bias_z = biases(2);
   
-  float gyro_y = gyro(1);
-  float gyro_z = gyro(2);
+  double gyro_y = gyro(1);
+  double gyro_z = gyro(2);
 
-  float phi = Theta(0);
-  float theta = Theta(1);
+  double phi = Theta(0);
+  double theta = Theta(1);
 
-  Eigen::Matrix3f S_Theta_jacobian;
+  Eigen::Matrix3d S_Theta_jacobian;
   S_Theta_jacobian << 
-  ((- bias_y + gyro_y)*cosf(phi) + (bias_z - gyro_z)*sinf(phi))*tanf(theta),
-  ((- bias_y + gyro_y)*sinf(phi) + (- bias_z + gyro_z)*cosf(phi))/(cosf(theta)*cosf(theta)),
+  ((- bias_y + gyro_y)*cos(phi) + (bias_z - gyro_z)*sin(phi))*tan(theta),
+  ((- bias_y + gyro_y)*sin(phi) + (- bias_z + gyro_z)*cos(phi))/(cos(theta)*cos(theta)),
   0.0,
-  (bias_y - gyro_y)*sinf(phi) + (bias_z - gyro_z)*cosf(phi),
+  (bias_y - gyro_y)*sin(phi) + (bias_z - gyro_z)*cos(phi),
   0.0,
   0.0,
-  ((- bias_y + gyro_y)*cosf(phi) + (bias_z - gyro_z)*sinf(phi))*(1.0/cosf(theta)), 
-  ((- bias_y + gyro_y)*sinf(phi) + (- bias_z + gyro_z)*cosf(phi))*tanf(theta)*(1.0/cosf(theta)), 
+  ((- bias_y + gyro_y)*cos(phi) + (bias_z - gyro_z)*sin(phi))*(1.0/cos(theta)), 
+  ((- bias_y + gyro_y)*sin(phi) + (- bias_z + gyro_z)*cos(phi))*tan(theta)*(1.0/cos(theta)), 
   0.0;
 
   return S_Theta_jacobian;
 }
 
-Eigen::Matrix<float, 3,3> EstimatorContinuousDiscrete::del_R_Theta_T_g_del_Theta(const Eigen::Vector3f& Theta, const double& gravity)
+Eigen::Matrix<double, 3,3> EstimatorContinuousDiscrete::del_R_Theta_T_g_del_Theta(const Eigen::Vector3d& Theta, const double& gravity)
 {
-  float phi = Theta(0);
-  float theta = Theta(1);
+  double phi = Theta(0);
+  double theta = Theta(1);
 
-  Eigen::Matrix<float, 3, 3> R_theta_T_g_jac;
+  Eigen::Matrix<double, 3, 3> R_theta_T_g_jac;
 
   R_theta_T_g_jac << 0.0, -gravity*cos(theta), 0.0,
                      gravity*cos(phi)*cos(theta), -gravity*sin(phi)*sin(theta), 0.0,
@@ -543,17 +552,17 @@ Eigen::Matrix<float, 3,3> EstimatorContinuousDiscrete::del_R_Theta_T_g_del_Theta
   return R_theta_T_g_jac;
 }
 
-Eigen::Matrix<float, 3,3> EstimatorContinuousDiscrete::del_R_Theta_v_del_Theta(const Eigen::Vector3f& Theta, const Eigen::Vector3f& vels)
+Eigen::Matrix<double, 3,3> EstimatorContinuousDiscrete::del_R_Theta_v_del_Theta(const Eigen::Vector3d& Theta, const Eigen::Vector3d& vels)
 {
-  float phi = Theta(0);
-  float theta = Theta(1);
-  float psi = Theta(2);
+  double phi = Theta(0);
+  double theta = Theta(1);
+  double psi = Theta(2);
 
-  float v_n = vels(0);
-  float v_e = vels(1);
-  float v_d = vels(2); 
+  double v_n = vels(0);
+  double v_e = vels(1);
+  double v_d = vels(2); 
 
-  Eigen::Matrix<float, 3, 3> R_theta_v_jac;
+  Eigen::Matrix<double, 3, 3> R_theta_v_jac;
 
   R_theta_v_jac << v_e*(sin(phi)*sin(psi) + sin(theta)*cos(phi)*cos(psi)) + v_d*(-sin(phi)*sin(theta)*cos(psi) + sin(psi)*cos(phi)),
                    (-v_n*sin(theta) + v_e*sin(phi)*cos(theta) + v_d*cos(phi)*cos(theta))*cos(psi),
@@ -569,20 +578,20 @@ Eigen::Matrix<float, 3,3> EstimatorContinuousDiscrete::del_R_Theta_v_del_Theta(c
 }
 
 // ======== MISC HELPER FUNCTIONS========
-Eigen::Vector3f EstimatorContinuousDiscrete::calculate_inertial_magnetic_field(const float& declination, const float& inclination)
+Eigen::Vector3d EstimatorContinuousDiscrete::calculate_inertial_magnetic_field(const double& declination, const double& inclination)
 {
   // The full intesity of the magnetic field is in the x axis in the magnetic frame.
-  Eigen::Vector3f mag_x = Eigen::Vector3f::UnitX();
+  Eigen::Vector3d mag_x = Eigen::Vector3d::UnitX();
 
-  Eigen::Matrix3f mag_inclination_rotation;
-  mag_inclination_rotation = Eigen::AngleAxisf(inclination, Eigen::Vector3f::UnitY()).toRotationMatrix();
+  Eigen::Matrix3d mag_inclination_rotation;
+  mag_inclination_rotation = Eigen::AngleAxisd(inclination, Eigen::Vector3d::UnitY()).toRotationMatrix();
   
-  Eigen::Matrix3f mag_declination_rotation;
-  mag_declination_rotation = Eigen::AngleAxisf(declination, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  Eigen::Matrix3d mag_declination_rotation;
+  mag_declination_rotation = Eigen::AngleAxisd(declination, Eigen::Vector3d::UnitZ()).toRotationMatrix();
   
   // Find the magnetic field intenisty described in the inertial frame by rotating the frame.
-  Eigen::Matrix3f mag_rotation = mag_declination_rotation*mag_inclination_rotation;
-  Eigen::Vector3f inertial_mag_readings = mag_rotation*mag_x;
+  Eigen::Matrix3d mag_rotation = mag_declination_rotation*mag_inclination_rotation;
+  Eigen::Vector3d inertial_mag_readings = mag_rotation*mag_x;
 
   return inertial_mag_readings/inertial_mag_readings.norm();
 }
@@ -590,8 +599,8 @@ Eigen::Vector3f EstimatorContinuousDiscrete::calculate_inertial_magnetic_field(c
 
 void EstimatorContinuousDiscrete::calc_mag_field_properties(const Input& input)
 {
-  float inclination = params_.get_double("inclination");
-  float declination = params_.get_double("declination");
+  double inclination = params_.get_double("inclination");
+  double declination = params_.get_double("declination");
 
   if ((0. <= inclination && inclination <= 90.) &&
       (-90. <= declination && declination <= 90.)) {
@@ -608,9 +617,9 @@ void EstimatorContinuousDiscrete::calc_mag_field_properties(const Input& input)
   double grid_variation; // Only useful for arctic or antarctic navigation (unused).
   
   // Take the current year and then add a decimal for the current day.
-  float decimal_year = input.gps_year + input.gps_yday/365.0f;
+  double decimal_year = input.gps_year + input.gps_yday/365.0;
 
-  int mag_success = geomag_calc(input.gps_alt/1000.0f,
+  int mag_success = geomag_calc(input.gps_alt/1000.0,
                                 input.gps_lat,
                                 input.gps_lon,
                                 decimal_year,
@@ -714,7 +723,7 @@ void EstimatorContinuousDiscrete::initialize_state_covariances()
   double bias_y_initial_cov = params_.get_double("bias_y_initial_cov");
   double bias_z_initial_cov = params_.get_double("bias_z_initial_cov");
   
-  P_ = Eigen::MatrixXf::Identity(num_states, num_states);
+  P_ = Eigen::MatrixXd::Identity(num_states, num_states);
   P_(0, 0) = pos_n_initial_cov;
   P_(1, 1) = pos_e_initial_cov;
   P_(2, 2) = pos_d_initial_cov;
@@ -742,11 +751,11 @@ void EstimatorContinuousDiscrete::initialize_process_noises()
   double velocity_vertical_process_noise = params_.get_double("vel_horizontal_process_noise");
   double bias_process_noise = params_.get_double("bias_process_noise");
   
-  Eigen::Vector<float, num_estimator_inputs> estimator_input_process_noises = Eigen::Vector<float, num_estimator_inputs>::Zero();
+  Eigen::Vector<double, num_estimator_inputs> estimator_input_process_noises = Eigen::Vector<double, num_estimator_inputs>::Zero();
   estimator_input_process_noises << pow(accel_process_noise,2), pow(accel_process_noise,2), pow(accel_process_noise,2),
                         pow(radians(gyro_process_noise), 2), pow(radians(gyro_process_noise), 2), pow(radians(gyro_process_noise), 2);
 
-  Q_inputs_ = Eigen::DiagonalMatrix<float,num_estimator_inputs>(estimator_input_process_noises);
+  Q_inputs_ = Eigen::DiagonalMatrix<double,num_estimator_inputs>(estimator_input_process_noises);
 
   Q_(0,0) = position_process_noise;
   Q_(1,1) = position_process_noise;
@@ -776,21 +785,21 @@ void EstimatorContinuousDiscrete::update_measurement_model_parameters()
   double sigma_tilt = params_.get_double("sigma_tilt_mag");
   double frequency = params_.get_double("estimator_update_frequency");
   double Ts = 1.0 / frequency;
-  float gyro_cutoff_freq = params_.get_double("gyro_cutoff_freq");
+  double gyro_cutoff_freq = params_.get_double("gyro_cutoff_freq");
 
-  R_gnss_(0, 0) = powf(sigma_n_gps, 2);
-  R_gnss_(1, 1) = powf(sigma_e_gps, 2);
-  R_gnss_(2, 2) = powf(sigma_vn_gps, 2);
-  R_gnss_(3, 3) = powf(sigma_ve_gps, 2);
-  R_gnss_(4, 4) = powf(sigma_vd_gps, 2);
+  R_gnss_(0, 0) = pow(sigma_n_gps, 2);
+  R_gnss_(1, 1) = pow(sigma_e_gps, 2);
+  R_gnss_(2, 2) = pow(sigma_vn_gps, 2);
+  R_gnss_(3, 3) = pow(sigma_ve_gps, 2);
+  R_gnss_(4, 4) = pow(sigma_vd_gps, 2);
   
-  R_baro_(0,0) = powf(sigma_static_press,2);
+  R_baro_(0,0) = pow(sigma_static_press,2);
 
-  R_mag_(0,0) = powf(sigma_mag,2);
-  R_mag_(1,1) = powf(sigma_mag,2);
-  R_mag_(2,2) = powf(sigma_mag,2);
+  R_mag_(0,0) = pow(sigma_mag,2);
+  R_mag_(1,1) = pow(sigma_mag,2);
+  R_mag_(2,2) = pow(sigma_mag,2);
   
-  R_tilt_(0,0) = powf(sigma_tilt,2);
+  R_tilt_(0,0) = pow(sigma_tilt,2);
   
   // Calculate low pass filter alpha values.
   alpha_gyro_ = exp(-2.*M_PI*gyro_cutoff_freq * Ts);
@@ -816,15 +825,15 @@ void EstimatorContinuousDiscrete::declare_parameters()
   params_.declare_double("baro_cutoff_freq", 1.25);
   
   // Proccess noises
-  params_.declare_double("roll_process_noise", 1000*powf(0.0001,2));
-  params_.declare_double("pitch_process_noise", 1000*powf(0.0001,2));
-  params_.declare_double("yaw_process_noise", 1000*powf(0.0001,2));
+  params_.declare_double("roll_process_noise", 1000*pow(0.0001,2));
+  params_.declare_double("pitch_process_noise", 1000*pow(0.0001,2));
+  params_.declare_double("yaw_process_noise", 1000*pow(0.0001,2));
   params_.declare_double("gyro_process_noise", 0.13);
   params_.declare_double("accel_process_noise", 0.24525);
-  params_.declare_double("pos_process_noise", 1000*powf(0.00003,2));
+  params_.declare_double("pos_process_noise", 1000*pow(0.00003,2));
   params_.declare_double("alt_process_noise", 1000*0.000001);
-  params_.declare_double("vel_horizontal_process_noise", 1000*powf(0.0001,2)); 
-  params_.declare_double("vel_vertical_process_noise", 1000*powf(0.0001,2));
+  params_.declare_double("vel_horizontal_process_noise", 1000*pow(0.0001,2)); 
+  params_.declare_double("vel_vertical_process_noise", 1000*pow(0.0001,2));
   params_.declare_double("bias_process_noise", 0.0000001*0.0000001);
   
   // Initial covariances

--- a/roscopter/src/ekf/estimator_ekf.cpp
+++ b/roscopter/src/ekf/estimator_ekf.cpp
@@ -14,19 +14,19 @@ EstimatorEKF::EstimatorEKF() : EstimatorROS()
   params_.set_parameters();
 }
 
-std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::kalman_update(Eigen::VectorXf x,
-                                                                         Eigen::VectorXf h,
-                                                                         Eigen::VectorXf y,
-                                                                         Eigen::MatrixXf C,
-                                                                         Eigen::MatrixXf R,
-                                                                         Eigen::MatrixXf S,
-                                                                         Eigen::MatrixXf P)
+std::tuple<Eigen::MatrixXd, Eigen::VectorXd> EstimatorEKF::kalman_update(Eigen::VectorXd x,
+                                                                         Eigen::VectorXd h,
+                                                                         Eigen::VectorXd y,
+                                                                         Eigen::MatrixXd C,
+                                                                         Eigen::MatrixXd R,
+                                                                         Eigen::MatrixXd S,
+                                                                         Eigen::MatrixXd P)
 
 {
   // Find the Kalman gain.
-  Eigen::MatrixXf L = P * C.transpose() * S.inverse();
+  Eigen::MatrixXd L = P * C.transpose() * S.inverse();
   // Use a temp to increase readablility.
-  Eigen::MatrixXf temp = Eigen::MatrixXf::Identity(x.size(), x.size()) - L * C;
+  Eigen::MatrixXd temp = Eigen::MatrixXd::Identity(x.size(), x.size()) - L * C;
   
   // Adjust the covariance with new information.
   // This uses Joseph's Stabilized form of the covariance update.
@@ -36,39 +36,39 @@ std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::kalman_update(Eigen::
   // Use Kalman gain to optimally adjust estimate.
   x = x + L * (y - h);
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> result(P, x);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> result(P, x);
   
   return result;
 }
 
-std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::measurement_update(Eigen::VectorXf x,
-                                                                Eigen::VectorXf inputs,
+std::tuple<Eigen::MatrixXd, Eigen::VectorXd> EstimatorEKF::measurement_update(Eigen::VectorXd x,
+                                                                Eigen::VectorXd inputs,
                                                                 MeasurementModelFuncRef measurement_model,
-                                                                Eigen::VectorXf y,
+                                                                Eigen::VectorXd y,
                                                                 JacobianFuncRef measurement_jacobian,
                                                                 SensorNoiseFuncRef sensor_noise_model,
-                                                                Eigen::MatrixXf P)
+                                                                Eigen::MatrixXd P)
 {
   
-  Eigen::VectorXf h = measurement_model(x, inputs);
-  Eigen::MatrixXf C = measurement_jacobian(x, inputs);
-  Eigen::MatrixXf R = sensor_noise_model(x, inputs);
+  Eigen::VectorXd h = measurement_model(x, inputs);
+  Eigen::MatrixXd C = measurement_jacobian(x, inputs);
+  Eigen::MatrixXd R = sensor_noise_model(x, inputs);
   
   // Find the innovation covariance and it's inverse to find the Kalman gain.
-  Eigen::MatrixXf S = (R + C * P * C.transpose());
+  Eigen::MatrixXd S = (R + C * P * C.transpose());
   
   return kalman_update(x, h, y, C, R, S, P);
 }
 
-std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::propagate_model(Eigen::VectorXf x,
+std::tuple<Eigen::MatrixXd, Eigen::VectorXd> EstimatorEKF::propagate_model(Eigen::VectorXd x,
                                                              DynamicModelFuncRef dynamic_model,
                                                              JacobianFuncRef jacobian,
-                                                             Eigen::VectorXf inputs,
+                                                             Eigen::VectorXd inputs,
                                                              JacobianFuncRef input_jacobian,
-                                                             Eigen::MatrixXf P,
-                                                             Eigen::MatrixXf Q,
-                                                             Eigen::MatrixXf Q_g,
-                                                             float Ts)
+                                                             Eigen::MatrixXd P,
+                                                             Eigen::MatrixXd Q,
+                                                             Eigen::MatrixXd Q_g,
+                                                             double Ts)
 {
 
   int N = params_.get_int("num_propagation_steps");
@@ -76,77 +76,77 @@ std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::propagate_model(Eigen
   for (int _ = 0; _ < N; _++)
   {
 
-    Eigen::VectorXf f = dynamic_model(x, inputs);
+    Eigen::VectorXd f = dynamic_model(x, inputs);
     // Propagate model by a step.
     x += f * (Ts/N);
 
-    Eigen::MatrixXf A = jacobian(x, inputs);
+    Eigen::MatrixXd A = jacobian(x, inputs);
     
     // Find the second order approx of the matrix exponential.
-    Eigen::MatrixXf A_d = Eigen::MatrixXf::Identity(A.rows(), A.cols()) + Ts / N * A
+    Eigen::MatrixXd A_d = Eigen::MatrixXd::Identity(A.rows(), A.cols()) + Ts / N * A
       + pow(Ts / N, 2) / 2.0 * A * A;
 
-    Eigen::MatrixXf G = input_jacobian(x, inputs);
+    Eigen::MatrixXd G = input_jacobian(x, inputs);
     
     // Propagate the covariance.
     P = A_d * P * A_d.transpose() + (Q + G * Q_g * G.transpose()) * pow(Ts / N, 2);
     
   }
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> result(P, x);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> result(P, x);
   
   return result;
 }
 
-std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::single_measurement_update(float measurement, float measurement_prediction,
-                                                                                     float measurement_variance, Eigen::VectorXf measurement_jacobian,
-                                                                                     Eigen::VectorXf x, Eigen::MatrixXf P)
+std::tuple<Eigen::MatrixXd, Eigen::VectorXd> EstimatorEKF::single_measurement_update(double measurement, double measurement_prediction,
+                                                                                     double measurement_variance, Eigen::VectorXd measurement_jacobian,
+                                                                                     Eigen::VectorXd x, Eigen::MatrixXd P)
 {
-  Eigen::MatrixXf I(x.size(),x.size());
-  I = Eigen::MatrixXf::Identity(x.size(), x.size());
-  Eigen::VectorXf L = (P * measurement_jacobian) / (measurement_variance + (measurement_jacobian.transpose() * P * measurement_jacobian));
+  Eigen::MatrixXd I(x.size(),x.size());
+  I = Eigen::MatrixXd::Identity(x.size(), x.size());
+  Eigen::VectorXd L = (P * measurement_jacobian) / (measurement_variance + (measurement_jacobian.transpose() * P * measurement_jacobian));
   P = (I - L * measurement_jacobian.transpose()) * P;
   x = x + L * (measurement - measurement_prediction);
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> result(P,x);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> result(P,x);
   return result;
 }
 
-std::tuple<Eigen::MatrixXf, Eigen::VectorXf> EstimatorEKF::partial_measurement_update(Eigen::VectorXf x,
-                                                                Eigen::VectorXf inputs,
+std::tuple<Eigen::MatrixXd, Eigen::VectorXd> EstimatorEKF::partial_measurement_update(Eigen::VectorXd x,
+                                                                Eigen::VectorXd inputs,
                                                                 MeasurementModelFuncRef measurement_model,
-                                                                Eigen::VectorXf y,
+                                                                Eigen::VectorXd y,
                                                                 JacobianFuncRef measurement_jacobian,
                                                                 SensorNoiseFuncRef sensor_noise_model,
-                                                                Eigen::MatrixXf P,
-                                                                Eigen::VectorXf gammas)
+                                                                Eigen::MatrixXd P,
+                                                                Eigen::VectorXd gammas)
 {
 
   // See Partial-Update Schmidt-Kalman Filter, Kevin Brink, 2017 Journal of Guidance, Control and Dynamics.
   // Specifcially Equations 68-69, the algorithm described in Section V subsection B.
   
-  Eigen::VectorXf h = measurement_model(x, inputs);
-  Eigen::MatrixXf C = measurement_jacobian(x, inputs);
-  Eigen::MatrixXf R = sensor_noise_model(x, inputs);
+  Eigen::VectorXd h = measurement_model(x, inputs);
+  Eigen::MatrixXd C = measurement_jacobian(x, inputs);
+  Eigen::MatrixXd R = sensor_noise_model(x, inputs);
   
   // Find the S_inv to find the Kalman gain.
-  Eigen::MatrixXf S = (R + C * P * C.transpose());
+  Eigen::MatrixXd S = (R + C * P * C.transpose());
   
-  Eigen::MatrixXf P_update;
-  Eigen::VectorXf x_update;
+  Eigen::MatrixXd P_update;
+  Eigen::VectorXd x_update;
 
   std::tie(P_update, x_update) = kalman_update(x, h, y, C, R, S, P);
 
-  Eigen::VectorXf ones = Eigen::VectorXf::Ones(x.size());
+  Eigen::VectorXd ones = Eigen::VectorXd::Ones(x.size());
 
   x = (gammas.array()*x.array()).matrix() + ((ones - gammas).array()*x_update.array()).matrix();
 
   auto gamma_outer_product = gammas*gammas.transpose();
-  Eigen::MatrixXf ones_matrix = Eigen::MatrixXf::Constant(x.size(), x.size(), 1);
+  Eigen::MatrixXd ones_matrix = Eigen::MatrixXd::Constant(x.size(), x.size(), 1);
   
   P = (gamma_outer_product.array() * P.array()).matrix() + ((ones_matrix-gamma_outer_product).array()*P_update.array()).matrix();
 
-  std::tuple<Eigen::MatrixXf, Eigen::VectorXf> result(P, x);
+  std::tuple<Eigen::MatrixXd, Eigen::VectorXd> result(P, x);
   
   return result;
 }

--- a/roscopter/src/ekf/estimator_ros.cpp
+++ b/roscopter/src/ekf/estimator_ros.cpp
@@ -71,7 +71,7 @@ void EstimatorROS::declare_parameters()
   params_.declare_int("max_mag_sensor_silence_duration_ms", 25); // actual publish rate is 50 Hz, measured max period of 22ms
   params_.declare_int("max_baro_sensor_silence_duration_ms", 15); // actual publish rate is 100 Hz, measured max period of 11ms
   params_.declare_int("max_gnss_sensor_silence_duration_ms", 110); // actual publish rate is 10 Hz, measured max period of 105ms
-  params_.declare_int("min_gnss_fix_type", 3); // Fix must be of type float.
+  params_.declare_int("min_gnss_fix_type", 3); // Fix must be of type double.
   params_.declare_bool("hotstart_estimator", false); // Whether the estimator should use preset hotstart values.
 }
 
@@ -193,11 +193,11 @@ void EstimatorROS::gnssCallback(const rosflight_msgs::msg::GNSS::SharedPtr msg)
   // Convert msg to standard DDS and m/s.
   double msg_lat = msg->lat;
   double msg_lon = msg->lon;
-  float msg_height = msg->alt;
+  double msg_height = msg->alt;
   
-  float msg_vel_n = msg->vel_n;
-  float msg_vel_e = msg->vel_e;
-  float msg_vel_d = msg->vel_d;
+  double msg_vel_n = msg->vel_n;
+  double msg_vel_e = msg->vel_e;
+  double msg_vel_d = msg->vel_d;
 
   has_fix_ = msg->fix_type >= min_fix_type; 
   
@@ -214,11 +214,11 @@ void EstimatorROS::gnssCallback(const rosflight_msgs::msg::GNSS::SharedPtr msg)
       init_lon_ = msg_lon;
 
       // Calculate the air density using the standard atmospheric model.
-      double pressure_at_alt = 101325.0f * (float) pow((1 - 2.25694e-5 * init_alt_), 5.2553);
+      double pressure_at_alt = 101325.0 * (double) pow((1 - 2.25694e-5 * init_alt_), 5.2553);
       rho_ = 1.225 * pow(pressure_at_alt / 101325.0, 0.809736894596450);
       
       // If the parameter is in use override the pressure at altitude calculation.
-      float rho = params_.get_double("rho");
+      double rho = params_.get_double("rho");
       if (rho > 0) {
         rho_ = rho;
       }
@@ -284,10 +284,10 @@ void EstimatorROS::baroAltCallback(const rosflight_msgs::msg::Barometer::SharedP
     update_barometer_calibration(msg);
   } else {
     // Save the barometer pressure, cap the maximum change registered.
-    float static_pres_old = input_.static_pres;
+    double static_pres_old = input_.static_pres;
     input_.static_pres = -msg->pressure + init_static_;
 
-    float gate_gain = gate_gain_constant * rho_ * gravity;
+    double gate_gain = gate_gain_constant * rho_ * gravity;
     if (input_.static_pres < static_pres_old - gate_gain) {
       input_.static_pres = static_pres_old - gate_gain;
     } else if (input_.static_pres > static_pres_old + gate_gain) {
@@ -312,11 +312,11 @@ void EstimatorROS::update_barometer_calibration(const rosflight_msgs::msg::Barom
 
     //Check that it got a good calibration.
     std::sort(init_static_vector_.begin(), init_static_vector_.end());
-    float q1 = (init_static_vector_[24] + init_static_vector_[25]) / 2.0;
-    float q3 = (init_static_vector_[74] + init_static_vector_[75]) / 2.0;
-    float IQR = q3 - q1;
-    float upper_bound = q3 + 2.0 * IQR;
-    float lower_bound = q1 - 2.0 * IQR;
+    double q1 = (init_static_vector_[24] + init_static_vector_[25]) / 2.0;
+    double q3 = (init_static_vector_[74] + init_static_vector_[75]) / 2.0;
+    double IQR = q3 - q1;
+    double upper_bound = q3 + 2.0 * IQR;
+    double lower_bound = q1 - 2.0 * IQR;
     for (int i = 0; i < baro_calib_count; i++) {
       if (init_static_vector_[i] > upper_bound) {
         baro_init_ = false;

--- a/roscopter/src/ekf/estimator_ros.cpp
+++ b/roscopter/src/ekf/estimator_ros.cpp
@@ -1,5 +1,10 @@
 #include "ekf/estimator_ros.hpp"
+
+#include <filesystem>
 #include <fstream>
+
+// #include <ament_index_cpp/get_package_share_path.hpp> // FIXME: use when Humble is dropped
+#include <rosflight_compat/get_package_share_path.hpp>
 
 namespace roscopter
 {
@@ -36,16 +41,14 @@ EstimatorROS::EstimatorROS()
   params_.set_parameters();
 
   params_initialized_ = true;
-  
-  std::filesystem::path workspace_dir = ament_index_cpp::get_package_share_directory("roscopter");
-  std::filesystem::path params_dir = "params";
-  std::filesystem::path hotstart_file = "hotstart";
 
-  std::filesystem::path install_hotstart_dir = workspace_dir / params_dir / hotstart_file;
+  // FIXME: use ament_index_cpp::get_package_share_path when Humble support is dropped
+  std::filesystem::path workspace_path = rosflight_compat::get_package_share_path("roscopter");
+  std::filesystem::path install_hotstart_path = workspace_path / "params" / "hotstart";
  
   // Remove the install and share directories from the path so the hotstart file goes into
   // the main directory so it is easily found.
-  for (auto dir : install_hotstart_dir) {
+  for (auto dir : install_hotstart_path) {
     if (dir.string() == "install") continue;
     if (dir.string() == "share") continue;
     hotstart_path_ /= dir;

--- a/roscopter/src/navigation/path_manager_ros.cpp
+++ b/roscopter/src/navigation/path_manager_ros.cpp
@@ -116,8 +116,9 @@ void PathManagerROS::single_waypoint_callback(const roscopter_msgs::msg::Waypoin
   waypoint_list_.push_back(msg);
 }
 
-bool PathManagerROS::clear_waypoints(const std_srvs::srv::Trigger::Request::SharedPtr &req,
-                                     const std_srvs::srv::Trigger::Response::SharedPtr &res)
+bool PathManagerROS::clear_waypoints(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr &req,
+  const std_srvs::srv::Trigger::Response::SharedPtr &res)
 {
   clear_waypoints_internally();
   
@@ -132,8 +133,9 @@ void PathManagerROS::publish_command(roscopter_msgs::msg::TrajectoryCommand &com
   cmd_pub_->publish(command);
 }
 
-bool PathManagerROS::print_path(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                             const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool PathManagerROS::print_path(
+  [[maybe_unused]]const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   std::stringstream output;
 

--- a/roscopter/src/navigation/path_planner.cpp
+++ b/roscopter/src/navigation/path_planner.cpp
@@ -1,6 +1,7 @@
 #include <functional>
 
 #include <rclcpp/executors.hpp>
+#include <yaml-cpp/yaml.h>
 #include <rosflight_compat/service_client.hpp>
 
 #include "navigation/path_planner.hpp"

--- a/roscopter/src/navigation/path_planner.cpp
+++ b/roscopter/src/navigation/path_planner.cpp
@@ -1,4 +1,7 @@
+#include <functional>
+
 #include <rclcpp/executors.hpp>
+#include <rosflight_compat/service_client.hpp>
 
 #include "navigation/path_planner.hpp"
 
@@ -14,7 +17,8 @@ PathPlanner::PathPlanner()
 {
   // Set up the callback groups for the clear wp service and the service client so they can execute properly
   client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  clear_wp_client_ = this->create_client<std_srvs::srv::Trigger>("/path_manager/clear_waypoints", rmw_qos_profile_services_default, client_cb_group_);
+  clear_wp_client_ = rosflight_compat::create_service_client<std_srvs::srv::Trigger>(
+    *this, "/path_manager/clear_waypoints", client_cb_group_);
 
   // Make this publisher transient_local so that it publishes the last 10 waypoints to late subscribers
   rclcpp::QoS qos_transient_local_10_(10);

--- a/roscopter/src/navigation/path_planner.cpp
+++ b/roscopter/src/navigation/path_planner.cpp
@@ -87,8 +87,9 @@ void PathPlanner::state_callback(const roscopter_msgs::msg::State & msg)
   }
 }
 
-bool PathPlanner::publish_next_waypoint(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                        const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool PathPlanner::publish_next_waypoint(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   // Publish the next waypoint, if available
   if (num_waypoints_published_ < (int) wps_.size()) {
@@ -163,8 +164,9 @@ bool PathPlanner::update_path(const roscopter_msgs::srv::AddWaypoint::Request::S
   return true;
 }
 
-bool PathPlanner::clear_path_callback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                      const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool PathPlanner::clear_path_callback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   res->success = clear_path();
 
@@ -183,8 +185,9 @@ bool PathPlanner::clear_path()
   return true;
 }
 
-bool PathPlanner::print_path(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                             const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool PathPlanner::print_path(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   std::stringstream output;
 

--- a/roscopter/src/navigation/trajectory_follower_ros.cpp
+++ b/roscopter/src/navigation/trajectory_follower_ros.cpp
@@ -106,8 +106,9 @@ void TrajectoryFollowerROS::publish_command(roscopter_msgs::msg::ControllerComma
   cmd_pub_->publish(command);
 }
 
-bool TrajectoryFollowerROS::clear_integrators_callback(const std_srvs::srv::Trigger::Request::SharedPtr req,
-                                                       const std_srvs::srv::Trigger::Response::SharedPtr res)
+bool TrajectoryFollowerROS::clear_integrators_callback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr req,
+  const std_srvs::srv::Trigger::Response::SharedPtr res)
 {
   clear_integrators();
   res->success = true;

--- a/roscopter/src/utils/geomag.c
+++ b/roscopter/src/utils/geomag.c
@@ -63,7 +63,7 @@ static char **wmm_lines;
 static char *wmm_string;
 static int wmm_index;
 static int maxdeg;
-static double epochlowlim,epochuplim,epoch;
+static double epochlowlim,epoch;
 char decd[7], dipd[7],modl[20];
 
 static int geomag_E0_init(int *maxdeg);

--- a/roscopter_gcs/CMakeLists.txt
+++ b/roscopter_gcs/CMakeLists.txt
@@ -1,21 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(roscopter_gcs)
-
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # find dependencies
@@ -23,51 +10,66 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(roscopter_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
-find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
-ament_export_dependencies(rclcpp visualization_msgs)
-
-install(DIRECTORY launch config resource DESTINATION share/${PROJECT_NAME})
+###################
+### EXECUTABLES ###
+###################
 
 # Waypoint publisher node executable
-add_executable(rviz_waypoint_publisher
-               src/rviz_waypoint_publisher.cpp)
-target_include_directories(rviz_waypoint_publisher
-  PRIVATE
-    include)
-ament_target_dependencies(rviz_waypoint_publisher
-  roscopter_msgs
-  visualization_msgs
-  rclcpp
-  tf2
-  tf2_ros
-  geometry_msgs
-  ament_index_cpp
+add_executable(rviz_waypoint_publisher src/rviz_waypoint_publisher.cpp)
+target_compile_features(rviz_waypoint_publisher PRIVATE cxx_std_17)
+target_compile_options(rviz_waypoint_publisher PRIVATE -Wall -Wextra -Wpedantic)
+target_include_directories(rviz_waypoint_publisher PRIVATE include)
+target_link_libraries(rviz_waypoint_publisher PRIVATE
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  visualization_msgs::visualization_msgs
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  roscopter_msgs::roscopter_msgs
 )
-install(TARGETS
-  rviz_waypoint_publisher
-  DESTINATION lib/${PROJECT_NAME})
 
 # Aircraft publisher node executable
-add_executable(rviz_aircraft_publisher
-               src/rviz_aircraft_publisher.cpp)
-target_include_directories(rviz_aircraft_publisher
-  PRIVATE
-    include)
-ament_target_dependencies(rviz_aircraft_publisher
-  roscopter_msgs
-  visualization_msgs
-  rclcpp
-  tf2
-  tf2_ros
-  geometry_msgs
-  ament_index_cpp
+add_executable(rviz_aircraft_publisher src/rviz_aircraft_publisher.cpp)
+target_compile_features(rviz_aircraft_publisher PRIVATE cxx_std_17)
+target_compile_options(rviz_aircraft_publisher PRIVATE -Wall -Wextra -Wpedantic)
+target_include_directories(rviz_aircraft_publisher PRIVATE include)
+target_link_libraries(rviz_aircraft_publisher PRIVATE
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  visualization_msgs::visualization_msgs
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  roscopter_msgs::roscopter_msgs
 )
-install(TARGETS
-  rviz_aircraft_publisher
-  DESTINATION lib/${PROJECT_NAME})
+
+###############
+### Install ###
+###############
+
+# C++ nodes/executables
+install(
+  TARGETS
+    rviz_waypoint_publisher
+    rviz_aircraft_publisher
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Resources
+install(
+  DIRECTORY
+    launch
+    config
+    resource
+  DESTINATION share/${PROJECT_NAME}
+)
+
+########################
+### ROS Finalization ###
+########################
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/roscopter_gcs/include/rviz_aircraft_publisher.hpp
+++ b/roscopter_gcs/include/rviz_aircraft_publisher.hpp
@@ -38,7 +38,7 @@
 
 #include <geometry_msgs/msg/point.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include "roscopter_msgs/msg/state.hpp"

--- a/roscopter_gcs/include/rviz_aircraft_publisher.hpp
+++ b/roscopter_gcs/include/rviz_aircraft_publisher.hpp
@@ -38,10 +38,9 @@
 
 #include <geometry_msgs/msg/point.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <roscopter_msgs/msg/state.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
-
-#include "roscopter_msgs/msg/state.hpp"
 
 namespace roscopter_gcs
 {

--- a/roscopter_gcs/include/rviz_waypoint_publisher.hpp
+++ b/roscopter_gcs/include/rviz_waypoint_publisher.hpp
@@ -5,9 +5,8 @@
 
 #include <geometry_msgs/msg/point.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <roscopter_msgs/msg/waypoint.hpp>
 #include <visualization_msgs/msg/marker.hpp>
-
-#include "roscopter_msgs/msg/waypoint.hpp"
 
 namespace roscopter_gcs
 {

--- a/roscopter_gcs/launch/roscopter_gcs.launch.py
+++ b/roscopter_gcs/launch/roscopter_gcs.launch.py
@@ -1,15 +1,14 @@
-import os 
-import sys
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
 
 def generate_launch_description():
     # Create the package directory
-    roscopter_gcs_dir = get_package_share_directory('roscopter_gcs')
+    roscopter_gcs_share = FindPackageShare('roscopter_gcs')
 
-    rviz2_config_file = roscopter_gcs_dir + '/config/roscopter_gcs.rviz'
-    rviz2_splash_file = roscopter_gcs_dir + '/resource/logo.png'
+    rviz2_config_file = PathJoinSubstitution([roscopter_gcs_share, '/config/roscopter_gcs.rviz'])
+    rviz2_splash_file = PathJoinSubstitution([roscopter_gcs_share, '/resource/logo.png'])
 
     return LaunchDescription([
         Node(

--- a/roscopter_gcs/package.xml
+++ b/roscopter_gcs/package.xml
@@ -10,8 +10,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>visualization_msgs</depend>
   <depend>roscopter_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/roscopter_gcs/src/rviz_aircraft_publisher.cpp
+++ b/roscopter_gcs/src/rviz_aircraft_publisher.cpp
@@ -35,11 +35,11 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <roscopter_msgs/msg/state.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
-#include "roscopter_msgs/msg/state.hpp"
 #include "rviz_aircraft_publisher.hpp"
 
 namespace roscopter_gcs

--- a/roscopter_gcs/src/rviz_aircraft_publisher.cpp
+++ b/roscopter_gcs/src/rviz_aircraft_publisher.cpp
@@ -35,8 +35,8 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include "roscopter_msgs/msg/state.hpp"

--- a/roscopter_gcs/src/rviz_waypoint_publisher.cpp
+++ b/roscopter_gcs/src/rviz_waypoint_publisher.cpp
@@ -1,7 +1,7 @@
 #include <rclcpp/rclcpp.hpp>
+#include <roscopter_msgs/msg/waypoint.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
-#include "roscopter_msgs/msg/waypoint.hpp"
 #include "rviz_waypoint_publisher.hpp"
 
 namespace roscopter_gcs

--- a/roscopter_msgs/CMakeLists.txt
+++ b/roscopter_msgs/CMakeLists.txt
@@ -1,20 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(roscopter_msgs)
-
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/roscopter_pkgs/CMakeLists.txt
+++ b/roscopter_pkgs/CMakeLists.txt
@@ -1,24 +1,11 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(roscopter_pkgs)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
+# Acknowledge variable does not need to be used since this file does not define
+# an executable (suppresses cmake warning)
+if(DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ${CMAKE_EXPORT_COMPILE_COMMANDS})
 endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-
-# find_package(catkin REQUIRED)
-# catkin_metapackage()
 
 find_package(ament_cmake REQUIRED)
 

--- a/roscopter_pkgs/package.xml
+++ b/roscopter_pkgs/package.xml
@@ -17,6 +17,12 @@
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
+  <exec_depend>roscopter</exec_depend>
+  <exec_depend>roscopter_msgs</exec_depend>
+  <exec_depend>roscopter_gcs</exec_depend>
+  <exec_depend>roscopter_sim</exec_depend>
+  <exec_depend>roscopter_tuning</exec_depend>
+
   <export>
     <!-- =========================================== -->
     <!-- ROS2 does not allow this tag -->

--- a/roscopter_sim/CMakeLists.txt
+++ b/roscopter_sim/CMakeLists.txt
@@ -1,84 +1,52 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(roscopter_sim)
 
-set(CMAKE_CXX_STANDARD 11)
 if (NOT CMAKE_BUILD_TYPE)
-    # Options: Debug, Release, MinSizeRel, RelWithDebInfo
-    message(STATUS "No build type selected, default to Release")
-    set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
-
-set(CMAKE_CXX_FLAGS "-fopenmp")
-
-# To enable assertions when compiled in release mode.
-add_definitions(-DROS_ASSERT_ENABLED)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(roscopter_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-# catkin_package(
-#   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
-#   CATKIN_DEPENDS roscpp rosflight_msgs rosflight_utils std_msgs nav_msgs geometry_msgs sensor_msgs std_srvs gazebo_ros gazebo_plugins
-#   DEPENDS EIGEN3 GAZEBO
-# )
+#################
+## Executables ##
+#################
 
-include_directories(include 
-  ${ament_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
+add_executable(sim_state_transcriber src/state_transcription_node.cpp)
+target_compile_features(sim_state_transcriber PRIVATE cxx_std_17)
+target_compile_options(sim_state_transcriber PRIVATE
+  -Wall -Wextra -Wpedantic
+  -fopenmp # TODO: is this necessary?
 )
-# link_directories(${GAZEBO_LIBRARY_DIRS})
-
-# add_library(multirotor_forces_and_moments_plugin src/multirotor_forces_and_moments.cpp)
-# target_link_libraries(multirotor_forces_and_moments_plugin 
-#   ${ament_INCLUDE_DIRS}
-#   ${rclcpp_INCLUDE_DIRS}
-#   ${GAZEBO_LIBRARIES}
-# )
-# # add_dependencies(multirotor_forces_and_moments_plugin ${catkin_EXPORTED_TARGETS})
-# ament_export_dependencies(
-#   multirotor_forces_and_moments_plugin
-#   rclcpp
-#   rosflight_msgs
-#   rosflight_utils
-#   std_msgs
-#   nav_msgs
-#   geometry_msgs
-#   sensor_msgs
-#   std_srvs
-#   gazebo_ros
-#   gazebo_plugins
-# )
-
-# install(
-#   TARGETS
-#     multirotor_forces_and_moments_plugin
-#   DESTINATION lib/${PROJECT_NAME}
-#   # LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-# )
-
-add_executable(sim_state_transcriber
-  src/state_transcription_node.cpp
+target_link_libraries(sim_state_transcriber PRIVATE
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  roscopter_msgs::roscopter_msgs
+  rosflight_msgs::rosflight_msgs
+  Eigen3::Eigen
 )
-target_link_libraries(sim_state_transcriber Eigen3::Eigen)
-ament_target_dependencies(sim_state_transcriber
-  rclcpp
-  geometry_msgs
-  nav_msgs
-  roscopter_msgs
-  rosflight_msgs)
-install(TARGETS
-        sim_state_transcriber
-        DESTINATION lib/${PROJECT_NAME})
 
-# Install other files
+#############
+## Install ##
+#############
+
+# C++ nodes/executables
 install(
-    DIRECTORY launch
-    DESTINATION share/${PROJECT_NAME})
+  TARGETS
+    sim_state_transcriber
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Resources
+install(
+  DIRECTORY
+    launch
+    params
+  DESTINATION share/${PROJECT_NAME}
+)
 
 ament_package()

--- a/roscopter_sim/include/roscopter_sim/common.h
+++ b/roscopter_sim/include/roscopter_sim/common.h
@@ -21,7 +21,7 @@
 #ifndef ROSCOPTER_SIM_COMMON_H_
 #define ROSCOPTER_SIM_COMMON_H_
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 #include <gazebo/gazebo.hh>
 
 namespace gazebo {

--- a/roscopter_sim/include/roscopter_sim/multirotor_forces_and_moments.h
+++ b/roscopter_sim/include/roscopter_sim/multirotor_forces_and_moments.h
@@ -22,7 +22,6 @@
 
 #include <vector>
 #include <thread>
-#include <eigen3/Eigen/Eigen>
 
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Plugin.hh>

--- a/roscopter_sim/include/roscopter_sim/multirotor_forces_and_moments.h
+++ b/roscopter_sim/include/roscopter_sim/multirotor_forces_and_moments.h
@@ -21,7 +21,7 @@
 #include <stdio.h>
 
 #include <vector>
-#include <boost/bind.hpp>
+#include <thread>
 #include <eigen3/Eigen/Eigen>
 
 #include <gazebo/common/common.hh>
@@ -132,7 +132,7 @@ private:
   ros::Subscriber wind_sub_;
   ros::Publisher attitude_pub_;
 
-  boost::thread callback_queue_thread_;
+  std::thread callback_queue_thread_;
   void QueueThread();
   void WindCallback(const geometry_msgs::Vector3& wind);
   void CommandCallback(const rosflight_msgs::Command msg);

--- a/roscopter_sim/launch/sim.launch.py
+++ b/roscopter_sim/launch/sim.launch.py
@@ -1,21 +1,17 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import IncludeLaunchDescription
-import os
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
 
 
 def generate_launch_description():
-    roscopter_dir = get_package_share_directory('roscopter')
+    roscopter_share = FindPackageShare('roscopter')
 
     base_launch_include = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(
-                roscopter_dir,
-                'launch',
-                'roscopter.launch.py'
-            )
+            PathJoinSubstitution([roscopter_share, 'launch', 'roscopter.launch.py'])
         )
     )
 

--- a/roscopter_sim/package.xml
+++ b/roscopter_sim/package.xml
@@ -18,12 +18,8 @@
 
   <!-- Dependencies needed to compile and for after this package is compiled -->
   <depend>geometry_msgs</depend>
-  <depend>std_srvs</depend>
   <depend>rosflight_msgs</depend>
   <depend>roscopter_msgs</depend>
-  <depend>nav_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
 
   <!-- =========================================== -->
 

--- a/roscopter_sim/src/multirotor_forces_and_moments.cpp
+++ b/roscopter_sim/src/multirotor_forces_and_moments.cpp
@@ -130,7 +130,8 @@ void MultiRotorForcesAndMoments::Load(physics::ModelPtr _model, sdf::ElementPtr 
   alt_controller_.setGains(altP, altI, altD);
 
   // Connect the update function to the simulation
-  updateConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&MultiRotorForcesAndMoments::OnUpdate, this, _1));
+  updateConnection_ = event::Events::ConnectWorldUpdateBegin(
+    [this](const common::UpdateInfo & info) { OnUpdate(info); });
 
   // Connect Subscribers
   command_sub_ = nh_->subscribe(command_topic_, 1, &MultiRotorForcesAndMoments::CommandCallback, this);

--- a/roscopter_sim/src/state_transcription_node.cpp
+++ b/roscopter_sim/src/state_transcription_node.cpp
@@ -58,7 +58,7 @@ private:
     state.p_d = msg.pose.position.z;
 
     // Quaternion is from body to inertial
-    Eigen::Quaternionf q;
+    Eigen::Quaterniond q;
     q.w() = msg.pose.orientation.w;
     q.x() = msg.pose.orientation.x;
     q.y() = msg.pose.orientation.y;
@@ -72,7 +72,7 @@ private:
                      pow(q.w(), 2) + pow(q.x(), 2) - pow(q.y(), 2) - pow(q.z(), 2));
 
     // Inertial linear velocities in body frame
-    Eigen::Vector3f body_frame_velocity(msg.twist.linear.x, msg.twist.linear.y, msg.twist.linear.z);
+    Eigen::Vector3d body_frame_velocity(msg.twist.linear.x, msg.twist.linear.y, msg.twist.linear.z);
     state.v_x = body_frame_velocity[0];
     state.v_y = body_frame_velocity[1];
     state.v_z = body_frame_velocity[2];

--- a/roscopter_sim/src/state_transcription_node.cpp
+++ b/roscopter_sim/src/state_transcription_node.cpp
@@ -1,11 +1,8 @@
-#include <memory>
-
 #include <Eigen/Geometry>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-
-#include "roscopter_msgs/msg/state.hpp"
-#include "rosflight_msgs/msg/sim_state.hpp"
+#include <roscopter_msgs/msg/state.hpp>
+#include <rosflight_msgs/msg/sim_state.hpp>
 
 namespace roscopter_sim {
 

--- a/roscopter_tuning/CMakeLists.txt
+++ b/roscopter_tuning/CMakeLists.txt
@@ -1,66 +1,53 @@
-set(CMAKE_CXX_STANDARD 14)
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(roscopter_tuning)
-
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclpy REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(roscopter_msgs REQUIRED)
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
-find_package(rosflight_msgs REQUIRED)
 
-ament_export_dependencies(rclcpp rclpy)
-ament_export_include_directories(include)
-
-install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY resources
-  DESTINATION share/${PROJECT_NAME}
-)
-
-include_directories(
-  include
-  ${ament_INCLUDE_DIRS})
-
-### START OF EXECUTABLES ###
+###################
+### EXECUTABLES ###
+###################
 
 # Signal Generator
-add_executable(signal_generator
-               src/signal_generator.cpp)
-ament_target_dependencies(signal_generator roscopter_msgs std_srvs rclcpp)
-target_compile_options(signal_generator PRIVATE -Wno-unused-parameter)
-install(TARGETS
-        signal_generator
-        DESTINATION lib/${PROJECT_NAME})
+add_executable(signal_generator src/signal_generator.cpp)
+target_compile_features(signal_generator PRIVATE cxx_std_17)
+target_compile_options(signal_generator PRIVATE -Wall -Wextra -Wpedantic)
+target_include_directories(signal_generator PRIVATE include)
+target_link_libraries(signal_generator PRIVATE
+  roscopter_msgs::roscopter_msgs
+  std_srvs::std_srvs
+  rclcpp::rclcpp
+)
 
-#### END OF EXECUTABLES ###
+###############
+### Install ###
+###############
+
+# C++ nodes/executables
+install(
+  TARGETS
+    signal_generator
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Resources
+install(
+  DIRECTORY
+    launch
+    resources
+  DESTINATION share/${PROJECT_NAME}
+)
+
+########################
+### ROS Finalization ###
+########################
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/roscopter_tuning/include/signal_generator.hpp
+++ b/roscopter_tuning/include/signal_generator.hpp
@@ -42,14 +42,13 @@
 #ifndef TUNING_SIGNAL_GENERATOR_HPP
 #define TUNING_SIGNAL_GENERATOR_HPP
 
-#include "roscopter_msgs/msg/controller_command.hpp"
+#include <unordered_set>
+
+#include <roscopter_msgs/msg/controller_command.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
-#include <unordered_set>
-#include <system_error>
-#include <sstream>
 
 namespace roscopter
 {

--- a/roscopter_tuning/launch/roscopter_tuning.launch.py
+++ b/roscopter_tuning/launch/roscopter_tuning.launch.py
@@ -1,26 +1,13 @@
-import os
-import sys
 from launch import LaunchDescription
-from launch.descriptions import executable
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
 
 def generate_launch_description():
     # Create the package directory
-    roscopter_dir = get_package_share_directory('roscopter')
+    roscopter_share = FindPackageShare('roscopter')
 
-    # Determine the appropriate control scheme.
-    control_type = "default"
-
-    for arg in sys.argv:
-        if arg.startswith("control_type:="):
-            control_type = arg.split(":=")[1]
-
-    autopilot_params = os.path.join(
-        roscopter_dir,
-        'params',
-        'multirotor.yaml'
-    )
+    autopilot_params = PathJoinSubstitution([roscopter_share, 'params', 'multirotor.yaml'])
 
     return LaunchDescription([
         Node(
@@ -31,7 +18,6 @@ def generate_launch_description():
                           {'pitch_tuning_override': False},
                           {'roll_tuning_override': True}],
             output = 'screen',
-            arguments = [control_type],
             remappings=[('estimated_state', 'state')]
         ),
         Node(

--- a/roscopter_tuning/launch/tuning_gui.launch.py
+++ b/roscopter_tuning/launch/tuning_gui.launch.py
@@ -1,16 +1,16 @@
-import os
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import PathJoinSubstitution
 
 def generate_launch_description():
-    roscopter_tuning_dir = get_package_share_directory('roscopter_tuning')
+    roscopter_tuning_share = FindPackageShare('roscopter_tuning')
 
-    tuning_config = os.path.join(
-        roscopter_tuning_dir,
+    tuning_config = PathJoinSubstitution([
+        roscopter_tuning_share,
         'resources',
         'param_tuning_config.yaml'
-    )
+    ])
 
     return LaunchDescription([
         Node(

--- a/roscopter_tuning/package.xml
+++ b/roscopter_tuning/package.xml
@@ -11,12 +11,8 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>rclpy</depend>
-  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>sensor_msgs</depend>
   <depend>roscopter_msgs</depend>
-  <depend>rosflight_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/roscopter_tuning/src/signal_generator.cpp
+++ b/roscopter_tuning/src/signal_generator.cpp
@@ -211,7 +211,7 @@ TuningSignalGenerator::param_callback(const std::vector<rclcpp::Parameter> & par
 }
 
 bool TuningSignalGenerator::step_toggle_service_callback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (signal_type_ != SignalType::STEP) {
@@ -231,7 +231,7 @@ bool TuningSignalGenerator::step_toggle_service_callback(
 }
 
 bool TuningSignalGenerator::reset_service_callback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   reset();
@@ -240,7 +240,7 @@ bool TuningSignalGenerator::reset_service_callback(
 }
 
 bool TuningSignalGenerator::pause_service_callback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (signal_type_ == SignalType::STEP) {
@@ -257,7 +257,7 @@ bool TuningSignalGenerator::pause_service_callback(
 }
 
 bool TuningSignalGenerator::start_continuous_service_callback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (signal_type_ == SignalType::STEP) {
@@ -274,7 +274,7 @@ bool TuningSignalGenerator::start_continuous_service_callback(
 }
 
 bool TuningSignalGenerator::start_single_service_callback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (signal_type_ == SignalType::STEP) {

--- a/roscopter_tuning/src/signal_generator.cpp
+++ b/roscopter_tuning/src/signal_generator.cpp
@@ -39,6 +39,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <sstream>
 #include <string>
 
 #include "signal_generator.hpp"


### PR DESCRIPTION
**Note: ROSflight must be updated before this PR will build successfully.**

## Summary

- Modernize CMake configuration across roscopter packages with target-based linking, explicit compile features, exports, and install rules
- Replace deprecated ROS launch/path APIs with launch substitutions
- Remove Boost usage in favor of the C++ standard library
- Convert EKF math types from float to double for consistency with ROS message/data types
- Clean up unused variables, stale dependencies, and include ordering
- Make roscopter_pkgs build all other packages (fixes #62)
- Builds cleanly!